### PR TITLE
Cartographie du réseau de tubelure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Instead:
 - **PUT/PATCH**: load the existing entity with `FindAsync`, verify it belongs to the route's érablière (`entity.IdErabliere != id → NotFound()`), then assign only the allowed fields. Do **not** call `_depot.Update(bodyEntity)` — it attaches the whole graph.
 - Validate any FK the client supplies (e.g. `IdArbre`, `IdLigneTubelure`) belongs to the same érablière before saving.
 
-This rule is enforced by `WriteEndpointsBindDtoNotEntityTest` in `ErabliereApi.Test`, which reflects over every controller and fails the build if a `POST`/`PUT`/`PATCH` action binds a type tracked as a `DbSet<>` on `ErabliereDbContext`. Several legacy controllers (`Baril`, `Dompeux`, `Alerte`, `DonneeCapteur`, `AlerteCapteur`, `ChirpStackSrvConfig`, `Donnee`, `IpInfo`) are grandfathered as known tech debt in that test's `ExceptionsConnues` list — do not add to it; migrate those to DTOs when you touch them (removing an entry is enforced too: a second test fails if an exception no longer matches a real violation).
+This rule is enforced by `WriteEndpointsBindDtoNotEntityTest` in `ErabliereApi.Test`, which reflects over every controller and fails the build if a `POST`/`PUT`/`PATCH` action binds a type tracked as a `DbSet<>` on `ErabliereDbContext`. Two admin-only endpoints (`Chirpstack` server-config create/edit and `IpInfo` import) remain grandfathered as assumed tech debt in that test's `ExceptionsConnues` list — they're reachable only by administrators, so the multi-tenant over-posting risk is low. Do not add to that list; migrate those to DTOs when you touch them (removing an entry is enforced too: a second test fails if an exception no longer matches a real violation).
 
 ## CI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+ErabliereApi is a maple-syrup-production (érablière) monitoring platform: an ASP.NET Core REST API plus an Angular web app, collecting sensor data (temperature, vacuum, tank level), alerts, reports, notes, and AI chat features. Much of the codebase — identifiers, routes, comments, docs — is in **French**; follow that convention when adding code.
+
+Project tracking lives in Azure DevOps: https://dev.azure.com/freddycoder/ErabliereAPI
+
+## Solution layout
+
+- `ErabliereApi/` — the ASP.NET Core web API (main project, targets .NET 9; `global.json` pins SDK 10 with `rollForward: latestMajor`).
+- `ErabliereModel/` — data-model project (`ErabliereApi.Donnees`), one entity per file (Erabliere, Capteur, DonneeCapteur, Alerte, ...). `Erabliere` is the root of the data hierarchy; most entities are owned by one.
+- `ErabliereIU/` — Angular 22 front-end. **It has its own `ErabliereIU/CLAUDE.md`** — read it before working there (dev server, Cypress tests, runtime config, MSAL auth).
+- `ErabliereAPI.Proxy/` — NSwag-generated C# client published to NuGet. Regenerated with NSwag Studio from the OpenAPI spec + `GenerateProxy.ps1` (see its Readme); don't hand-edit generated files.
+- `ErabliereApi.Test/` (unit), `ErabliereApi.Integration.Test/` (in-memory `WebApplicationFactory` + AngleSharp; includes Stripe webhook JSON fixtures), `ErabliereApi.Test.Autofixture/` — all xUnit.
+- `Infrastructure/`, `docker-compose*.yaml`, `Dockerfile` — Kubernetes/docker deployment; `PythonScripts/` — device/data-feeding scripts; `Postman/` — API collections.
+
+## Commands
+
+Backend (from repo root):
+- `dotnet build ErabliereApi.sln`
+- `dotnet test` — all test projects. Single project: `dotnet test ErabliereApi.Test`. Single test: `dotnet test --filter "FullyQualifiedName~MyTestName"`.
+- `.\start-code-coverage-report.ps1` — tests with coverage + HTML report in `coveragereport/` (needs `reportgenerator` tool).
+- Run the API alone: `dotnet watch run` in `ErabliereApi/` (Development uses HTTP 5000 / HTTPS 5001).
+
+Full stack:
+- `.\start-light.ps1` — starts the API (`dotnet watch`) and the Angular dev server (`npm start`, https://localhost:4200). Pass `-startStripe $true` to also forward Stripe webhooks.
+- `.\start-local-debug-services.ps1` — same plus Stripe CLI login/listen and optional sibling repos (EmailImagesObserver, ErabliereWS, JeuxDonneesErabliereAPI).
+
+Docker: `docker build -t erabliereapi:local .` at the repo root; `docker compose up -d` for a local deployment.
+
+EF Core migrations (from `ErabliereApi/`, requires `dotnet-ef` and the `SQL_CONNEXION_STRING` + `USE_SQL` **machine environment variables** — the ef tool ignores launchSettings.json):
+```
+dotnet ef --startup-project . migrations add <Name> --output-dir "Depot\Sql\Migrations" --namespace "Depot.Sql.Migrations"
+```
+
+## Configuration is environment-variable driven
+
+Nearly every feature is toggled by string-compared config values read in `Startup.cs` / `Extensions/ServiceCollectionExtension.cs` (e.g. `"true"`/`"false"` strings). Key ones:
+- `USE_AUTHENTICATION` — turn auth on/off (locally: `dotnet user-secrets set USE_AUTHENTICATION false`).
+- `USE_SQL`, `SQL_CONNEXION_STRING`, `SQL_USE_STARTUP_MIGRATION` — `false` runs fully in-memory (no persistence, handy for dev); `SQL_USE_STARTUP_MIGRATION=true` applies migrations at API startup.
+- `USE_CORS`, `USE_HSTS`, `LOG_SQL`, `MiniProfiler.Enable`, `Stripe.*` (Stripe integration, webhooks at `/Checkout/Webhook` via the Stripe CLI).
+
+Local secrets go through `dotnet user-secrets`, not appsettings.
+
+## Backend architecture
+
+- `Program.cs` → `Startup.cs`, which delegates most registration to extension methods in `Extensions/` (`AddErabliereApiControllers`, `AddErabliereAPIAuthentication`, `AddDatabase`, `AddHttpClients`, ...). New services are wired there, not inline in Startup.
+- Controllers in `Controllers/` (one per resource, French names: `ErablieresController`, `CapteurController`, `DonneesCapteurController`, ...) expose **OData-style querying** (`$filter`, `$expand`, `$orderby`) consumed by the Angular app's `erabliereapi.service.ts`.
+- Data access is a single EF Core `ErabliereDbContext` (`Depot/Sql/`), entity configurations in `Depot/Sql/EntityConfiguration/`, migrations in `Depot/Sql/Migrations/`.
+- Cross-cutting concerns: `Authorization/` (API keys, customer access to érablières), `Middlewares/`, `Services/` (AI, ApiKey, Checkout/Stripe, IpInfo, LoRaWAN/ChirpStack, Nmap, Notifications, Users, Weather), Prometheus metrics, health checks, MiniProfiler.
+- The API serves the built Angular app from `wwwroot/`; building the UI into it (`ng build --output-path="..\ErabliereApi\wwwroot\."`) gives a same-origin setup that preserves the custom `x-ddr`/`x-dde` delta-range headers used to minimize transferred sensor data.
+
+## CI
+
+GitHub Actions (`.github/workflows/`): `api-image.yml` (docker image), `api-test-demo.yml` (tests), `codeql-analysis.yml`, `proxy-publish.yaml` (NuGet proxy package).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,18 @@ Local secrets go through `dotnet user-secrets`, not appsettings.
 - Cross-cutting concerns: `Authorization/` (API keys, customer access to érablières), `Middlewares/`, `Services/` (AI, ApiKey, Checkout/Stripe, IpInfo, LoRaWAN/ChirpStack, Nmap, Notifications, Users, Weather), Prometheus metrics, health checks, MiniProfiler.
 - The API serves the built Angular app from `wwwroot/`; building the UI into it (`ng build --output-path="..\ErabliereApi\wwwroot\."`) gives a same-origin setup that preserves the custom `x-ddr`/`x-dde` delta-range headers used to minimize transferred sensor data.
 
+### No entity binding on write endpoints (anti over-posting) — REQUIRED
+
+Never bind an EF entity from `ErabliereApi.Donnees` (e.g. `Erabliere`, `Capteur`, `Arbre`, `Entaille`, `LigneTubelure`, ...) directly as the body parameter of a `POST`/`PUT`/`PATCH` action. Because EF Core traverses the object graph on `AddAsync`/`Update`, an authenticated attacker can populate an entity's **navigation properties** (`Erabliere`, `Entailles`, `Arbre`, ...) to create or modify rows in an érablière they don't own — bypassing `ValiderOwnership` and the sibling controllers' checks (this is what happened on the tubelure feature). The `ValiderOwnership("id")` filter and the `id != body.IdErabliere` guard only protect the root entity, never the nested children.
+
+Instead:
+- **Bind a dedicated DTO** from `ErabliereApi.Donnees.Action.Post` / `.Put` that contains only scalar fields and foreign-key ids — **no navigation properties** (see `PostEntaille`, `PutLigneTubelure`, `PostCapteur`, ...).
+- **POST**: build the entity explicitly field-by-field before `AddAsync` (or `MapTo<TEntity>()`, which copies by name and thus can't set navigations the DTO doesn't have).
+- **PUT/PATCH**: load the existing entity with `FindAsync`, verify it belongs to the route's érablière (`entity.IdErabliere != id → NotFound()`), then assign only the allowed fields. Do **not** call `_depot.Update(bodyEntity)` — it attaches the whole graph.
+- Validate any FK the client supplies (e.g. `IdArbre`, `IdLigneTubelure`) belongs to the same érablière before saving.
+
+This rule is enforced by `WriteEndpointsBindDtoNotEntityTest` in `ErabliereApi.Test`, which reflects over every controller and fails the build if a `POST`/`PUT`/`PATCH` action binds a type tracked as a `DbSet<>` on `ErabliereDbContext`. Several legacy controllers (`Baril`, `Dompeux`, `Alerte`, `DonneeCapteur`, `AlerteCapteur`, `ChirpStackSrvConfig`, `Donnee`, `IpInfo`) are grandfathered as known tech debt in that test's `ExceptionsConnues` list — do not add to it; migrate those to DTOs when you touch them (removing an entry is enforced too: a second test fails if an exception no longer matches a real violation).
+
 ## CI
 
 GitHub Actions (`.github/workflows/`): `api-image.yml` (docker image), `api-test-demo.yml` (tests), `codeql-analysis.yml`, `proxy-publish.yaml` (NuGet proxy package).

--- a/ErabliereApi.Integration.Test/OverPostingMigrationTest.cs
+++ b/ErabliereApi.Integration.Test/OverPostingMigrationTest.cs
@@ -1,0 +1,167 @@
+using ErabliereApi.Depot.Sql;
+using ErabliereApi.Donnees;
+using ErabliereApi.Donnees.Action.Post;
+using ErabliereApi.Integration.Test.ApplicationFactory;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ErabliereApi.Integration.Test;
+
+/// <summary>
+/// Régression (anti over-posting) pour les contrôleurs migrés vers des DTO : Baril (nav imbriquée
+/// + PUT cross-tenant) et Donnees/Importer (override de la clé étrangère d'érablière).
+/// </summary>
+public class OverPostingMigrationTest : IClassFixture<StripeEnabledApplicationFactory<Startup>>
+{
+    private readonly StripeEnabledApplicationFactory<Startup> _factory;
+
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public OverPostingMigrationTest(StripeEnabledApplicationFactory<Startup> factory)
+    {
+        _factory = factory;
+    }
+
+    private async Task<(HttpClient client, Guid idErabliere)> CreerClientEtErabliere()
+    {
+        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = true,
+            HandleCookies = true,
+            MaxAutomaticRedirections = 7
+        });
+
+        var (_, apiKey) = await _factory.CreateValidApiKeyAsync();
+
+        client.DefaultRequestHeaders.Add("X-ErabliereApi-ApiKey", apiKey);
+
+        var response = await client.PostAsJsonAsync("/Erablieres", new PostErabliere
+        {
+            Nom = $"OPM-{Guid.NewGuid()}",
+            IpRules = "-"
+        });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
+
+        var erabliere = JsonSerializer.Deserialize<Erabliere>(
+            await response.Content.ReadAsStringAsync(), _jsonOptions);
+
+        Assert.NotNull(erabliere?.Id);
+
+        return (client, erabliere.Id.Value);
+    }
+
+    [Fact]
+    public async Task PostBaril_AvecErabliereImbriquee_NeModifiePasErabliereVictime()
+    {
+        var (clientAttaquant, idErabliereA) = await CreerClientEtErabliere();
+        var (_, idErabliereVictimeB) = await CreerClientEtErabliere();
+
+        string nomOriginalVictime;
+
+        using (var scopeAvant = _factory.Services.CreateScope())
+        {
+            var ctx = scopeAvant.ServiceProvider.GetRequiredService<ErabliereDbContext>();
+            nomOriginalVictime = (await ctx.Erabliere.AsNoTracking().FirstAsync(e => e.Id == idErabliereVictimeB)).Nom!;
+        }
+
+        var payload = new
+        {
+            idErabliere = idErabliereA,
+            q = "AA",
+            erabliere = new
+            {
+                id = idErabliereVictimeB,
+                nom = "ERABLIERE-VOLEE",
+                isPublic = true
+            }
+        };
+
+        var response = await clientAttaquant.PostAsJsonAsync($"/Erablieres/{idErabliereA}/Baril", payload);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
+
+        using var scope = _factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ErabliereDbContext>();
+
+        var victime = await context.Erabliere.AsNoTracking().FirstAsync(e => e.Id == idErabliereVictimeB);
+        victime.Nom.ShouldBe(nomOriginalVictime, "L'érablière de la victime ne doit pas être modifiée.");
+        victime.IsPublic.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task PutBaril_DUneAutreErabliere_RetourneNotFound()
+    {
+        var (clientAttaquant, idErabliereA) = await CreerClientEtErabliere();
+        var (_, idErabliereVictimeB) = await CreerClientEtErabliere();
+
+        Guid idBarilVictime;
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var ctx = scope.ServiceProvider.GetRequiredService<ErabliereDbContext>();
+            var baril = new Baril { IdErabliere = idErabliereVictimeB, Q = "original" };
+            await ctx.Barils.AddAsync(baril);
+            await ctx.SaveChangesAsync();
+            idBarilVictime = baril.Id!.Value;
+        }
+
+        var response = await clientAttaquant.PutAsJsonAsync($"/Erablieres/{idErabliereA}/Baril", new
+        {
+            id = idBarilVictime,
+            idErabliere = idErabliereA,
+            q = "detourne"
+        });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound, await response.Content.ReadAsStringAsync());
+
+        using var scopeApres = _factory.Services.CreateScope();
+        var contextApres = scopeApres.ServiceProvider.GetRequiredService<ErabliereDbContext>();
+        var barilApres = await contextApres.Barils.AsNoTracking().FirstAsync(b => b.Id == idBarilVictime);
+
+        barilApres.Q.ShouldBe("original", "Le baril de la victime ne doit pas être modifié.");
+        barilApres.IdErabliere.ShouldBe(idErabliereVictimeB, "Le baril ne doit pas être volé.");
+    }
+
+    [Fact]
+    public async Task ImporterDonnees_IgnoreLIdErabliereDuCorps_EtUtiliseCelleDeLaRoute()
+    {
+        var (clientAttaquant, idErabliereA) = await CreerClientEtErabliere();
+        var (_, idErabliereVictimeB) = await CreerClientEtErabliere();
+
+        var payload = new[]
+        {
+            new { idErabliere = idErabliereVictimeB, t = (short)10, v = (short)20, nb = (short)30 }
+        };
+
+        var response = await clientAttaquant.PostAsJsonAsync($"/Erablieres/{idErabliereA}/Donnees/Importer", payload);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
+
+        using var scope = _factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ErabliereDbContext>();
+
+        var donneesVictime = await context.Donnees.AsNoTracking()
+            .Where(d => d.IdErabliere == idErabliereVictimeB)
+            .ToListAsync();
+        donneesVictime.ShouldBeEmpty("Aucune donnée ne doit être importée dans l'érablière de la victime.");
+
+        var donneesA = await context.Donnees.AsNoTracking()
+            .Where(d => d.IdErabliere == idErabliereA)
+            .ToListAsync();
+        donneesA.Count.ShouldBe(1, "La donnée doit être importée dans l'érablière de la route.");
+    }
+}

--- a/ErabliereApi.Integration.Test/TubelureTest.cs
+++ b/ErabliereApi.Integration.Test/TubelureTest.cs
@@ -1,0 +1,246 @@
+using ErabliereApi.Depot.Sql;
+using ErabliereApi.Donnees;
+using ErabliereApi.Donnees.Action.Post;
+using ErabliereApi.Integration.Test.ApplicationFactory;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ErabliereApi.Integration.Test;
+
+public class TubelureTest : IClassFixture<StripeEnabledApplicationFactory<Startup>>
+{
+    private readonly StripeEnabledApplicationFactory<Startup> _factory;
+
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public TubelureTest(StripeEnabledApplicationFactory<Startup> factory)
+    {
+        _factory = factory;
+    }
+
+    private async Task<(HttpClient client, Guid idErabliere)> CreerClientEtErabliere()
+    {
+        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = true,
+            HandleCookies = true,
+            MaxAutomaticRedirections = 7
+        });
+
+        var (_, apiKey) = await _factory.CreateValidApiKeyAsync();
+
+        client.DefaultRequestHeaders.Add("X-ErabliereApi-ApiKey", apiKey);
+
+        var response = await client.PostAsJsonAsync("/Erablieres", new PostErabliere
+        {
+            Nom = $"ET-{Guid.NewGuid()}",
+            IpRules = "-"
+        });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
+
+        var erabliere = JsonSerializer.Deserialize<Erabliere>(
+            await response.Content.ReadAsStringAsync(), _jsonOptions);
+
+        Assert.NotNull(erabliere?.Id);
+
+        return (client, erabliere.Id.Value);
+    }
+
+    private static async Task<Guid> LireIdReponse(HttpResponseMessage response)
+    {
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+
+        return document.RootElement.GetProperty("id").GetGuid();
+    }
+
+    [Fact]
+    public async Task PosterLigneValide()
+    {
+        var (client, idErabliere) = await CreerClientEtErabliere();
+
+        var response = await client.PostAsJsonAsync($"/Erablieres/{idErabliere}/LignesTubelure", new LigneTubelure
+        {
+            IdErabliere = idErabliere,
+            Nom = "M-01",
+            TypeLigne = "Principale",
+            CoordonneesJson = "[[-71.25,46.82],[-71.26,46.83],[-71.27,46.84]]"
+        });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
+
+        var idLigne = await LireIdReponse(response);
+
+        using var scope = _factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ErabliereDbContext>();
+        var ligne = await context.LignesTubelure.FirstOrDefaultAsync(l => l.Id == idLigne);
+
+        Assert.NotNull(ligne);
+        Assert.Equal(idErabliere, ligne.IdErabliere);
+        Assert.Equal("M-01", ligne.Nom);
+        Assert.Equal("principale", ligne.TypeLigne);
+        Assert.Equal("[[-71.25,46.82],[-71.26,46.83],[-71.27,46.84]]", ligne.CoordonneesJson);
+        Assert.NotNull(ligne.DC);
+    }
+
+    [Fact]
+    public async Task PosterLigneTypeInvalide()
+    {
+        var (client, idErabliere) = await CreerClientEtErabliere();
+
+        var response = await client.PostAsJsonAsync($"/Erablieres/{idErabliere}/LignesTubelure", new LigneTubelure
+        {
+            IdErabliere = idErabliere,
+            TypeLigne = "diagonale",
+            CoordonneesJson = "[[-71.25,46.82],[-71.26,46.83]]"
+        });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest, await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task PosterLigneCoordonneesInvalides()
+    {
+        var (client, idErabliere) = await CreerClientEtErabliere();
+
+        // Un seul point
+        var response = await client.PostAsJsonAsync($"/Erablieres/{idErabliere}/LignesTubelure", new LigneTubelure
+        {
+            IdErabliere = idErabliere,
+            TypeLigne = "laterale",
+            CoordonneesJson = "[[-71.25,46.82]]"
+        });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest, await response.Content.ReadAsStringAsync());
+
+        // Latitude hors borne
+        response = await client.PostAsJsonAsync($"/Erablieres/{idErabliere}/LignesTubelure", new LigneTubelure
+        {
+            IdErabliere = idErabliere,
+            TypeLigne = "laterale",
+            CoordonneesJson = "[[-71.25,95],[-71.26,46.83]]"
+        });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest, await response.Content.ReadAsStringAsync());
+
+        // JSON invalide
+        response = await client.PostAsJsonAsync($"/Erablieres/{idErabliere}/LignesTubelure", new LigneTubelure
+        {
+            IdErabliere = idErabliere,
+            TypeLigne = "laterale",
+            CoordonneesJson = "pas du json"
+        });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest, await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task ArbreEntailleGeoJsonEtSuppression()
+    {
+        var (client, idErabliere) = await CreerClientEtErabliere();
+
+        // Ajouter une ligne
+        var responseLigne = await client.PostAsJsonAsync($"/Erablieres/{idErabliere}/LignesTubelure", new LigneTubelure
+        {
+            IdErabliere = idErabliere,
+            Nom = "L-01",
+            TypeLigne = "laterale",
+            CoordonneesJson = "[[-71.25,46.82],[-71.26,46.83]]"
+        });
+
+        responseLigne.StatusCode.ShouldBe(HttpStatusCode.OK, await responseLigne.Content.ReadAsStringAsync());
+        var idLigne = await LireIdReponse(responseLigne);
+
+        // Ajouter un arbre
+        var responseArbre = await client.PostAsJsonAsync($"/Erablieres/{idErabliere}/Arbres", new Arbre
+        {
+            IdErabliere = idErabliere,
+            Nom = "A-01",
+            Espece = "Érable à sucre",
+            Latitude = 46.825,
+            Longitude = -71.255
+        });
+
+        responseArbre.StatusCode.ShouldBe(HttpStatusCode.OK, await responseArbre.Content.ReadAsStringAsync());
+        var idArbre = await LireIdReponse(responseArbre);
+
+        // Ajouter une entaille liée à l'arbre et à la ligne
+        var responseEntaille = await client.PostAsJsonAsync($"/Erablieres/{idErabliere}/Entailles", new Entaille
+        {
+            IdErabliere = idErabliere,
+            Nom = "E-01",
+            Latitude = 46.8251,
+            Longitude = -71.2551,
+            IdArbre = idArbre,
+            IdLigneTubelure = idLigne
+        });
+
+        responseEntaille.StatusCode.ShouldBe(HttpStatusCode.OK, await responseEntaille.Content.ReadAsStringAsync());
+        var idEntaille = await LireIdReponse(responseEntaille);
+
+        // GeoJson : une FeatureCollection avec 3 features
+        var responseGeoJson = await client.GetAsync($"/Erablieres/{idErabliere}/Tubelure/GeoJson");
+
+        responseGeoJson.StatusCode.ShouldBe(HttpStatusCode.OK, await responseGeoJson.Content.ReadAsStringAsync());
+
+        using var geoJson = JsonDocument.Parse(await responseGeoJson.Content.ReadAsStringAsync());
+
+        Assert.Equal("FeatureCollection", geoJson.RootElement.GetProperty("type").GetString());
+        Assert.Equal(3, geoJson.RootElement.GetProperty("features").GetArrayLength());
+
+        // Supprimer l'arbre : l'entaille survit, mais son lien vers l'arbre est retiré
+        var responseDelete = await client.DeleteAsync($"/Erablieres/{idErabliere}/Arbres/{idArbre}");
+
+        responseDelete.StatusCode.ShouldBe(HttpStatusCode.NoContent, await responseDelete.Content.ReadAsStringAsync());
+
+        using var scope = _factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ErabliereDbContext>();
+        var entaille = await context.Entailles.AsNoTracking().FirstOrDefaultAsync(e => e.Id == idEntaille);
+
+        Assert.NotNull(entaille);
+        Assert.Null(entaille.IdArbre);
+        Assert.Equal(idLigne, entaille.IdLigneTubelure);
+    }
+
+    [Fact]
+    public async Task PosterEntailleAvecArbreDUneAutreErabliere()
+    {
+        var (client, idErabliereA) = await CreerClientEtErabliere();
+        var (_, idErabliereB) = await CreerClientEtErabliere();
+
+        // L'arbre appartient à l'érablière B
+        using var scope = _factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ErabliereDbContext>();
+        var arbre = new Arbre
+        {
+            IdErabliere = idErabliereB,
+            Latitude = 46.82,
+            Longitude = -71.25
+        };
+        await context.Arbres.AddAsync(arbre);
+        await context.SaveChangesAsync();
+
+        // L'entaille de l'érablière A ne peut pas référencer l'arbre de l'érablière B
+        var response = await client.PostAsJsonAsync($"/Erablieres/{idErabliereA}/Entailles", new Entaille
+        {
+            IdErabliere = idErabliereA,
+            Latitude = 46.82,
+            Longitude = -71.25,
+            IdArbre = arbre.Id
+        });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest, await response.Content.ReadAsStringAsync());
+    }
+}

--- a/ErabliereApi.Integration.Test/TubelureTest.cs
+++ b/ErabliereApi.Integration.Test/TubelureTest.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
@@ -242,5 +243,233 @@ public class TubelureTest : IClassFixture<StripeEnabledApplicationFactory<Startu
         });
 
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest, await response.Content.ReadAsStringAsync());
+    }
+
+    /// <summary>
+    /// Régression (over-posting) : un attaquant qui possède l'érablière A ne doit pas pouvoir
+    /// créer une entaille dans l'érablière B d'une victime en l'imbriquant dans la propriété
+    /// de navigation "entailles" d'une ligne postée sur sa propre érablière.
+    /// </summary>
+    [Fact]
+    public async Task PostLigne_NePeutPasCreerEntailleDansUneAutreErabliere()
+    {
+        var (clientAttaquant, idErabliereA) = await CreerClientEtErabliere();
+        var (_, idErabliereVictimeB) = await CreerClientEtErabliere();
+
+        var payload = new
+        {
+            idErabliere = idErabliereA,
+            nom = "ligne-anodine",
+            typeLigne = "principale",
+            coordonneesJson = "[[-71.25,46.82],[-71.26,46.83]]",
+            entailles = new[]
+            {
+                new
+                {
+                    idErabliere = idErabliereVictimeB,
+                    nom = "PWNED",
+                    latitude = 0.0,
+                    longitude = 0.0
+                }
+            }
+        };
+
+        var response = await clientAttaquant.PostAsJsonAsync($"/Erablieres/{idErabliereA}/LignesTubelure", payload);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
+
+        using var scope = _factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ErabliereDbContext>();
+
+        var entaillesVictime = await context.Entailles.AsNoTracking()
+            .Where(e => e.IdErabliere == idErabliereVictimeB)
+            .ToListAsync();
+
+        entaillesVictime.ShouldBeEmpty("Aucune entaille ne doit être créée dans l'érablière de la victime.");
+    }
+
+    /// <summary>
+    /// Régression (over-posting) : un attaquant ne doit pas pouvoir créer un arbre dans
+    /// l'érablière d'une victime en l'imbriquant dans la propriété de navigation "arbre"
+    /// d'une entaille postée sur sa propre érablière.
+    /// </summary>
+    [Fact]
+    public async Task PostEntaille_NePeutPasCreerArbreDansUneAutreErabliere()
+    {
+        var (clientAttaquant, idErabliereA) = await CreerClientEtErabliere();
+        var (_, idErabliereVictimeB) = await CreerClientEtErabliere();
+
+        var payload = new
+        {
+            idErabliere = idErabliereA,
+            nom = "entaille-anodine",
+            latitude = 46.82,
+            longitude = -71.25,
+            arbre = new
+            {
+                idErabliere = idErabliereVictimeB,
+                nom = "ARBRE-PWNED",
+                espece = "Injecte",
+                latitude = 0.0,
+                longitude = 0.0
+            }
+        };
+
+        var response = await clientAttaquant.PostAsJsonAsync($"/Erablieres/{idErabliereA}/Entailles", payload);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
+
+        using var scope = _factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ErabliereDbContext>();
+
+        var arbresVictime = await context.Arbres.AsNoTracking()
+            .Where(a => a.IdErabliere == idErabliereVictimeB)
+            .ToListAsync();
+
+        arbresVictime.ShouldBeEmpty("Aucun arbre ne doit être créé dans l'érablière de la victime.");
+    }
+
+    /// <summary>
+    /// Régression (over-posting) : un PUT sur une ligne avec une érablière imbriquée dans la
+    /// propriété de navigation ne doit pas modifier l'érablière de la victime.
+    /// </summary>
+    [Fact]
+    public async Task PutLigne_NeModifiePasErabliereImbriquee()
+    {
+        var (clientAttaquant, idErabliereA) = await CreerClientEtErabliere();
+        var (_, idErabliereVictimeB) = await CreerClientEtErabliere();
+
+        string nomOriginalVictime;
+
+        using (var scopeAvant = _factory.Services.CreateScope())
+        {
+            var ctx = scopeAvant.ServiceProvider.GetRequiredService<ErabliereDbContext>();
+            var victime = await ctx.Erabliere.AsNoTracking().FirstAsync(e => e.Id == idErabliereVictimeB);
+            nomOriginalVictime = victime.Nom!;
+        }
+
+        var responseCreation = await clientAttaquant.PostAsJsonAsync($"/Erablieres/{idErabliereA}/LignesTubelure", new LigneTubelure
+        {
+            IdErabliere = idErabliereA,
+            Nom = "L-01",
+            TypeLigne = "principale",
+            CoordonneesJson = "[[-71.25,46.82],[-71.26,46.83]]"
+        });
+
+        responseCreation.StatusCode.ShouldBe(HttpStatusCode.OK, await responseCreation.Content.ReadAsStringAsync());
+        var idLigne = await LireIdReponse(responseCreation);
+
+        var payload = new
+        {
+            id = idLigne,
+            idErabliere = idErabliereA,
+            nom = "L-01",
+            typeLigne = "principale",
+            coordonneesJson = "[[-71.25,46.82],[-71.26,46.83]]",
+            erabliere = new
+            {
+                id = idErabliereVictimeB,
+                nom = "ERABLIERE-VOLEE",
+                isPublic = true
+            }
+        };
+
+        var response = await clientAttaquant.PutAsJsonAsync($"/Erablieres/{idErabliereA}/LignesTubelure", payload);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent, await response.Content.ReadAsStringAsync());
+
+        using var scope = _factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ErabliereDbContext>();
+        var victimeApres = await context.Erabliere.AsNoTracking().FirstAsync(e => e.Id == idErabliereVictimeB);
+
+        victimeApres.Nom.ShouldBe(nomOriginalVictime, "L'érablière de la victime ne doit pas être modifiée.");
+        victimeApres.IsPublic.ShouldBeFalse("L'érablière de la victime ne doit pas devenir publique.");
+    }
+
+    /// <summary>
+    /// Régression : un PUT ne peut modifier qu'une ligne appartenant à l'érablière de la route.
+    /// Tenter de modifier une ligne d'une autre érablière retourne 404.
+    /// </summary>
+    [Fact]
+    public async Task PutLigne_DUneAutreErabliere_RetourneNotFound()
+    {
+        var (clientAttaquant, idErabliereA) = await CreerClientEtErabliere();
+        var (_, idErabliereVictimeB) = await CreerClientEtErabliere();
+
+        // Une ligne existante appartenant à la victime B
+        Guid idLigneVictime;
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var ctx = scope.ServiceProvider.GetRequiredService<ErabliereDbContext>();
+            var ligneVictime = new LigneTubelure
+            {
+                IdErabliere = idErabliereVictimeB,
+                Nom = "victime",
+                TypeLigne = "principale",
+                CoordonneesJson = "[[-71.25,46.82],[-71.26,46.83]]"
+            };
+            await ctx.LignesTubelure.AddAsync(ligneVictime);
+            await ctx.SaveChangesAsync();
+            idLigneVictime = ligneVictime.Id!.Value;
+        }
+
+        // L'attaquant tente de la modifier via sa propre érablière A
+        var response = await clientAttaquant.PutAsJsonAsync($"/Erablieres/{idErabliereA}/LignesTubelure", new LigneTubelure
+        {
+            Id = idLigneVictime,
+            IdErabliere = idErabliereA,
+            Nom = "detourne",
+            TypeLigne = "principale",
+            CoordonneesJson = "[[-71.25,46.82],[-71.26,46.83]]"
+        });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound, await response.Content.ReadAsStringAsync());
+
+        using var scopeApres = _factory.Services.CreateScope();
+        var contextApres = scopeApres.ServiceProvider.GetRequiredService<ErabliereDbContext>();
+        var ligneApres = await contextApres.LignesTubelure.AsNoTracking().FirstAsync(l => l.Id == idLigneVictime);
+
+        ligneApres.Nom.ShouldBe("victime", "La ligne de la victime ne doit pas être modifiée.");
+        ligneApres.IdErabliere.ShouldBe(idErabliereVictimeB, "La ligne ne doit pas être volée par l'attaquant.");
+    }
+
+    /// <summary>
+    /// Cas positif : un PUT légitime met bien à jour les champs autorisés de la ligne.
+    /// </summary>
+    [Fact]
+    public async Task PutLigne_MetAJourLesChampsLegitimes()
+    {
+        var (client, idErabliere) = await CreerClientEtErabliere();
+
+        var responseCreation = await client.PostAsJsonAsync($"/Erablieres/{idErabliere}/LignesTubelure", new LigneTubelure
+        {
+            IdErabliere = idErabliere,
+            Nom = "avant",
+            TypeLigne = "principale",
+            CoordonneesJson = "[[-71.25,46.82],[-71.26,46.83]]"
+        });
+
+        responseCreation.StatusCode.ShouldBe(HttpStatusCode.OK, await responseCreation.Content.ReadAsStringAsync());
+        var idLigne = await LireIdReponse(responseCreation);
+
+        var response = await client.PutAsJsonAsync($"/Erablieres/{idErabliere}/LignesTubelure", new LigneTubelure
+        {
+            Id = idLigne,
+            IdErabliere = idErabliere,
+            Nom = "apres",
+            TypeLigne = "Laterale",
+            CoordonneesJson = "[[-71.25,46.82],[-71.26,46.83],[-71.27,46.84]]"
+        });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent, await response.Content.ReadAsStringAsync());
+
+        using var scope = _factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ErabliereDbContext>();
+        var ligne = await context.LignesTubelure.AsNoTracking().FirstAsync(l => l.Id == idLigne);
+
+        ligne.Nom.ShouldBe("apres");
+        ligne.TypeLigne.ShouldBe("laterale");
+        ligne.CoordonneesJson.ShouldBe("[[-71.25,46.82],[-71.26,46.83],[-71.27,46.84]]");
     }
 }

--- a/ErabliereApi.Test.Autofixture/ErabliereFixture.cs
+++ b/ErabliereApi.Test.Autofixture/ErabliereFixture.cs
@@ -51,7 +51,20 @@ public static class ErabliereFixture
                                            .Without(e => e.Capteurs)
                                            .Without(e => e.Inspections)
                                            .Without(e => e.CustomerErablieres)
-                                           .Without(e => e.Horaires));
+                                           .Without(e => e.Horaires)
+                                           .Without(e => e.LignesTubelure)
+                                           .Without(e => e.Arbres)
+                                           .Without(e => e.Entailles));
+
+        fixture.Customize<LigneTubelure>(c => c.Without(l => l.Erabliere)
+                                               .Without(l => l.Entailles));
+
+        fixture.Customize<Arbre>(c => c.Without(a => a.Erabliere)
+                                       .Without(a => a.Entailles));
+
+        fixture.Customize<Entaille>(c => c.Without(e => e.Erabliere)
+                                          .Without(e => e.Arbre)
+                                          .Without(e => e.LigneTubelure));
 
         fixture.Customize<Donnee>(c => c.With(d => d.D, RandomDate(from: MinDate, to: MaxDate))
                                         .Without(d => d.Erabliere)

--- a/ErabliereApi.Test/WriteEndpointsBindDtoNotEntityTest.cs
+++ b/ErabliereApi.Test/WriteEndpointsBindDtoNotEntityTest.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using ErabliereApi.Controllers;
+using ErabliereApi.Depot.Sql;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ErabliereApi.Test;
+
+/// <summary>
+/// Test d'architecture (anti over-posting) : aucune action POST/PUT/PATCH d'un contrôleur
+/// ne doit lier une entité EF (namespace <c>ErabliereApi.Donnees</c>) comme corps de requête.
+/// Il faut utiliser un DTO dédié (<c>ErabliereApi.Donnees.Action.Post</c> / <c>.Put</c>) sans
+/// propriété de navigation. Voir la section « No entity binding on write endpoints » du CLAUDE.md.
+/// </summary>
+public class WriteEndpointsBindDtoNotEntityTest
+{
+    private readonly ITestOutputHelper _output;
+
+    public WriteEndpointsBindDtoNotEntityTest(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    /// <summary>
+    /// Dette technique connue : contrôleurs qui lient encore une entité EF brute. Ne pas allonger
+    /// cette liste — migrer vers un DTO quand on touche à ces contrôleurs.
+    /// Format des clés : "NomController.NomMethode(NomType)".
+    /// </summary>
+    private static readonly HashSet<string> ExceptionsConnues = new()
+    {
+        "AlerteCapteursController.Ajouter(AlerteCapteur)",
+        "AlertesController.Modifier(Alerte)",
+        "BarilController.Ajouter(Baril)",
+        "BarilController.Modifier(Baril)",
+        "ChirpstackController.CreateConfigs(ChirpStackSrvConfig)",
+        "ChirpstackController.EditConfigs(ChirpStackSrvConfig)",
+        "DompeuxController.Ajouter(Dompeux)",
+        "DompeuxController.Modifier(Dompeux)",
+        "DonneesCapteurController.Modifier(DonneeCapteur)",
+        "DonneesController.Importer(Donnee)",
+        "IpInfoController.ImportIpInfo(IpInfo)",
+    };
+
+    [Fact]
+    public void AucunEndpointDEcriture_NeLieUneEntite_HorsExceptionsConnues()
+    {
+        var violations = TrouverViolations().ToList();
+
+        foreach (var v in violations)
+        {
+            _output.WriteLine(v);
+        }
+
+        var nouvellesViolations = violations
+            .Where(v => !ExceptionsConnues.Contains(v))
+            .ToList();
+
+        Assert.True(
+            nouvellesViolations.Count == 0,
+            "Ces actions POST/PUT/PATCH lient une entité EF au lieu d'un DTO (risque d'over-posting). " +
+            "Créez un DTO Post*/Put* sans propriété de navigation. Voir CLAUDE.md.\n" +
+            string.Join("\n", nouvellesViolations));
+    }
+
+    /// <summary>
+    /// Vérifie que la liste d'exceptions ne contient pas d'entrée périmée (contrôleur déjà
+    /// migré vers un DTO). Force le nettoyage de la dette au fur et à mesure.
+    /// </summary>
+    [Fact]
+    public void ExceptionsConnues_NeContiennentPasDEntreePerimee()
+    {
+        var violations = TrouverViolations().ToHashSet();
+
+        var perimees = ExceptionsConnues.Where(e => !violations.Contains(e)).ToList();
+
+        Assert.True(
+            perimees.Count == 0,
+            "Ces exceptions ne correspondent plus à une violation réelle (contrôleur migré ?). " +
+            "Retirez-les de ExceptionsConnues :\n" + string.Join("\n", perimees));
+    }
+
+    private static IEnumerable<string> TrouverViolations()
+    {
+        var entites = TypesEntites();
+        var assembly = typeof(ArbresController).Assembly;
+
+        var controllers = assembly.GetTypes()
+            .Where(t => t.IsClass && !t.IsAbstract && typeof(ControllerBase).IsAssignableFrom(t));
+
+        foreach (var controller in controllers)
+        {
+            var methods = controller.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+            foreach (var method in methods)
+            {
+                if (!EstEndpointDEcriture(method))
+                {
+                    continue;
+                }
+
+                foreach (var parametre in method.GetParameters())
+                {
+                    var typeLie = TypeModeleLie(parametre.ParameterType);
+
+                    if (typeLie != null && entites.Contains(typeLie))
+                    {
+                        yield return $"{controller.Name}.{method.Name}({typeLie.Name})";
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// L'ensemble des types suivis par EF, c.-à-d. exposés comme <c>DbSet&lt;T&gt;</c> sur le
+    /// <see cref="ErabliereDbContext" />. Ce sont exactement les types dont le graphe est
+    /// traversé par <c>AddAsync</c>/<c>Update</c> — donc à risque d'over-posting.
+    /// </summary>
+    private static HashSet<Type> TypesEntites()
+    {
+        return typeof(ErabliereDbContext).GetProperties()
+            .Where(p => p.PropertyType.IsGenericType &&
+                        p.PropertyType.GetGenericTypeDefinition() == typeof(DbSet<>))
+            .Select(p => p.PropertyType.GetGenericArguments()[0])
+            .ToHashSet();
+    }
+
+    private static bool EstEndpointDEcriture(MethodInfo method)
+    {
+        return method.GetCustomAttributes().Any(a =>
+            a is HttpPostAttribute || a is HttpPutAttribute || a is HttpPatchAttribute);
+    }
+
+    /// <summary>
+    /// Retourne le type de modèle candidat au binding de corps : le type lui-même, ou l'élément
+    /// s'il s'agit d'un tableau ou d'une collection générique. Retourne null pour les types simples.
+    /// </summary>
+    private static Type? TypeModeleLie(Type type)
+    {
+        if (type.IsArray)
+        {
+            return TypeModeleLie(type.GetElementType()!);
+        }
+
+        if (type.IsGenericType && typeof(IEnumerable).IsAssignableFrom(type))
+        {
+            var arg = type.GetGenericArguments().FirstOrDefault();
+            return arg != null ? TypeModeleLie(arg) : null;
+        }
+
+        if (type.IsClass && type != typeof(string))
+        {
+            return type;
+        }
+
+        return null;
+    }
+}

--- a/ErabliereApi.Test/WriteEndpointsBindDtoNotEntityTest.cs
+++ b/ErabliereApi.Test/WriteEndpointsBindDtoNotEntityTest.cs
@@ -31,19 +31,13 @@ public class WriteEndpointsBindDtoNotEntityTest
     /// Dette technique connue : contrôleurs qui lient encore une entité EF brute. Ne pas allonger
     /// cette liste — migrer vers un DTO quand on touche à ces contrôleurs.
     /// Format des clés : "NomController.NomMethode(NomType)".
+    /// Les entrées restantes sont réservées aux administrateurs (acteurs de confiance, risque
+    /// d'over-posting faible) et sont laissées en dette assumée.
     /// </summary>
     private static readonly HashSet<string> ExceptionsConnues = new()
     {
-        "AlerteCapteursController.Ajouter(AlerteCapteur)",
-        "AlertesController.Modifier(Alerte)",
-        "BarilController.Ajouter(Baril)",
-        "BarilController.Modifier(Baril)",
         "ChirpstackController.CreateConfigs(ChirpStackSrvConfig)",
         "ChirpstackController.EditConfigs(ChirpStackSrvConfig)",
-        "DompeuxController.Ajouter(Dompeux)",
-        "DompeuxController.Modifier(Dompeux)",
-        "DonneesCapteurController.Modifier(DonneeCapteur)",
-        "DonneesController.Importer(Donnee)",
         "IpInfoController.ImportIpInfo(IpInfo)",
     };
 

--- a/ErabliereApi/Controllers/AlerteCapteursController.cs
+++ b/ErabliereApi/Controllers/AlerteCapteursController.cs
@@ -1,6 +1,7 @@
 ﻿using ErabliereApi.Attributes;
 using ErabliereApi.Depot.Sql;
 using ErabliereApi.Donnees;
+using ErabliereApi.Donnees.Action.Post;
 using ErabliereApi.Donnees.Action.Put;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -89,7 +90,7 @@ public class AlerteCapteursController : ControllerBase
     /// <response code="400">Le capteur n'existe pas</response>
     [HttpPost]
     [ValiderOwnership("id", typeof(Capteur))]
-    public async Task<IActionResult> Ajouter(Guid id, AlerteCapteur alerte, CancellationToken token)
+    public async Task<IActionResult> Ajouter(Guid id, PostAlerteCapteur alerte, CancellationToken token)
     {
         if (id != alerte.IdCapteur)
         {
@@ -101,12 +102,18 @@ public class AlerteCapteursController : ControllerBase
             return BadRequest("Le capteur n'existe pas");
         }
 
-        if (!alerte.DC.HasValue)
+        var entity = await _depot.AlerteCapteurs.AddAsync(new AlerteCapteur
         {
-            alerte.DC = DateTime.Now;
-        }
-
-        var entity = await _depot.AlerteCapteurs.AddAsync(alerte, token);
+            Id = alerte.Id,
+            IdCapteur = alerte.IdCapteur,
+            Nom = alerte.Nom,
+            EnvoyerA = alerte.EnvoyerA,
+            TexterA = alerte.TexterA,
+            MinValue = alerte.MinValue,
+            MaxValue = alerte.MaxValue,
+            IsEnable = alerte.IsEnable,
+            DC = alerte.DC ?? DateTime.Now
+        }, token);
 
         await _depot.SaveChangesAsync(token);
 

--- a/ErabliereApi/Controllers/AlertesController.cs
+++ b/ErabliereApi/Controllers/AlertesController.cs
@@ -3,6 +3,7 @@ using ErabliereApi.Action.Post;
 using ErabliereApi.Attributes;
 using ErabliereApi.Depot.Sql;
 using ErabliereApi.Donnees;
+using ErabliereApi.Donnees.Action.Put;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OData.Query;
@@ -97,22 +98,39 @@ public class AlertesController : ControllerBase
     /// <response code="400">L'id de la route ne concorde pas avec l'id du baril à modifier.</response>
     [HttpPut]
     [ValiderOwnership("id")]
-    public async Task<IActionResult> Modifier(Guid id, Alerte alerte, CancellationToken token)
+    public async Task<IActionResult> Modifier(Guid id, PutAlerte alerte, CancellationToken token)
     {
         if (id != alerte.IdErabliere)
         {
             return BadRequest("L'id de la route ne concorde pas avec l'id de l'alerte à modifier.");
         }
-        if (alerte.Erabliere != null)
+        if (alerte.Id == null)
         {
-            return BadRequest("L'érablière ne peut pas être modifié via cette route.");
+            return BadRequest("L'id de l'alerte à modifier est requis.");
         }
 
-        var entity = _depot.Update(alerte);
+        var entity = await _depot.Alertes.FindAsync([alerte.Id], cancellationToken: token);
+
+        if (entity == null || entity.IdErabliere != id)
+        {
+            return NotFound();
+        }
+
+        entity.Nom = alerte.Nom;
+        entity.EnvoyerA = alerte.EnvoyerA;
+        entity.TexterA = alerte.TexterA;
+        entity.TemperatureThresholdLow = alerte.TemperatureThresholdLow;
+        entity.TemperatureThresholdHight = alerte.TemperatureThresholdHight;
+        entity.VacciumThresholdLow = alerte.VacciumThresholdLow;
+        entity.VacciumThresholdHight = alerte.VacciumThresholdHight;
+        entity.NiveauBassinThresholdLow = alerte.NiveauBassinThresholdLow;
+        entity.NiveauBassinThresholdHight = alerte.NiveauBassinThresholdHight;
+        entity.IsEnable = alerte.IsEnable;
+        entity.DM = DateTimeOffset.UtcNow;
 
         await _depot.SaveChangesAsync(token);
 
-        return Ok(entity.Entity);
+        return Ok(entity);
     }
 
     /// <summary>

--- a/ErabliereApi/Controllers/ArbresController.cs
+++ b/ErabliereApi/Controllers/ArbresController.cs
@@ -1,6 +1,8 @@
 using ErabliereApi.Attributes;
 using ErabliereApi.Depot.Sql;
 using ErabliereApi.Donnees;
+using ErabliereApi.Donnees.Action.Post;
+using ErabliereApi.Donnees.Action.Put;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OData.Query;
@@ -50,7 +52,7 @@ public class ArbresController : ControllerBase
     /// <response code="400">La validation de l'arbre a échoué.</response>
     [HttpPost]
     [ValiderOwnership("id")]
-    public async Task<IActionResult> Ajouter(Guid id, Arbre arbre, CancellationToken token)
+    public async Task<IActionResult> Ajouter(Guid id, PostArbre arbre, CancellationToken token)
     {
         if (id != arbre.IdErabliere)
         {
@@ -62,10 +64,17 @@ public class ArbresController : ControllerBase
             return BadRequest("L'arbre doit avoir une longitude entre -180 et 180 et une latitude entre -90 et 90.");
         }
 
-        arbre.DC = DateTimeOffset.Now;
-        arbre.DM = DateTimeOffset.Now;
-
-        var entity = await _depot.Arbres.AddAsync(arbre, token);
+        var entity = await _depot.Arbres.AddAsync(new Arbre
+        {
+            Id = arbre.Id,
+            IdErabliere = arbre.IdErabliere,
+            Nom = arbre.Nom,
+            Espece = arbre.Espece,
+            Latitude = arbre.Latitude,
+            Longitude = arbre.Longitude,
+            DC = DateTimeOffset.Now,
+            DM = DateTimeOffset.Now
+        }, token);
 
         await _depot.SaveChangesAsync(token);
 
@@ -82,11 +91,16 @@ public class ArbresController : ControllerBase
     /// <response code="400">La validation de l'arbre a échoué.</response>
     [HttpPut]
     [ValiderOwnership("id")]
-    public async Task<IActionResult> Modifier(Guid id, Arbre arbre, CancellationToken token)
+    public async Task<IActionResult> Modifier(Guid id, PutArbre arbre, CancellationToken token)
     {
         if (id != arbre.IdErabliere)
         {
             return BadRequest("L'id de la route ne concorde pas avec l'id de l'arbre à modifier.");
+        }
+
+        if (arbre.Id == null)
+        {
+            return BadRequest("L'id de l'arbre à modifier est requis.");
         }
 
         if (!CoordonneesValides(arbre.Latitude, arbre.Longitude))
@@ -94,9 +108,18 @@ public class ArbresController : ControllerBase
             return BadRequest("L'arbre doit avoir une longitude entre -180 et 180 et une latitude entre -90 et 90.");
         }
 
-        arbre.DM = DateTimeOffset.Now;
+        var entity = await _depot.Arbres.FindAsync([arbre.Id], token);
 
-        _depot.Update(arbre);
+        if (entity == null || entity.IdErabliere != id)
+        {
+            return NotFound();
+        }
+
+        entity.Nom = arbre.Nom;
+        entity.Espece = arbre.Espece;
+        entity.Latitude = arbre.Latitude;
+        entity.Longitude = arbre.Longitude;
+        entity.DM = DateTimeOffset.Now;
 
         await _depot.SaveChangesAsync(token);
 

--- a/ErabliereApi/Controllers/ArbresController.cs
+++ b/ErabliereApi/Controllers/ArbresController.cs
@@ -1,0 +1,149 @@
+using ErabliereApi.Attributes;
+using ErabliereApi.Depot.Sql;
+using ErabliereApi.Donnees;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.EntityFrameworkCore;
+
+namespace ErabliereApi.Controllers;
+
+/// <summary>
+/// Contrôler représentant les arbres cartographiés d'une érablière
+/// </summary>
+[ApiController]
+[Route("Erablieres/{id}/[controller]")]
+[Authorize]
+public class ArbresController : ControllerBase
+{
+    private readonly ErabliereDbContext _depot;
+
+    /// <summary>
+    /// Constructeur par initialisation
+    /// </summary>
+    /// <param name="depot">Le dépôt des arbres</param>
+    public ArbresController(ErabliereDbContext depot)
+    {
+        _depot = depot;
+    }
+
+    /// <summary>
+    /// Lister les arbres avec les fonctionnalités de OData
+    /// </summary>
+    /// <param name="id">Identifiant de l'érablière</param>
+    /// <response code="200">Une liste d'arbres potentiellement vide.</response>
+    [HttpGet]
+    [EnableQuery]
+    [ValiderOwnership("id")]
+    public IQueryable<Arbre> Lister(Guid id)
+    {
+        return _depot.Arbres.AsNoTracking().Where(a => a.IdErabliere == id);
+    }
+
+    /// <summary>
+    /// Ajouter un arbre
+    /// </summary>
+    /// <param name="id">L'identifiant de l'érablière</param>
+    /// <param name="arbre">L'arbre à ajouter</param>
+    /// <param name="token">Le token d'annulation</param>
+    /// <response code="200">L'arbre a été correctement ajouté.</response>
+    /// <response code="400">La validation de l'arbre a échoué.</response>
+    [HttpPost]
+    [ValiderOwnership("id")]
+    public async Task<IActionResult> Ajouter(Guid id, Arbre arbre, CancellationToken token)
+    {
+        if (id != arbre.IdErabliere)
+        {
+            return BadRequest("L'id de la route ne concorde pas avec l'id de l'arbre à ajouter.");
+        }
+
+        if (!CoordonneesValides(arbre.Latitude, arbre.Longitude))
+        {
+            return BadRequest("L'arbre doit avoir une longitude entre -180 et 180 et une latitude entre -90 et 90.");
+        }
+
+        arbre.DC = DateTimeOffset.Now;
+        arbre.DM = DateTimeOffset.Now;
+
+        var entity = await _depot.Arbres.AddAsync(arbre, token);
+
+        await _depot.SaveChangesAsync(token);
+
+        return Ok(new { id = entity.Entity.Id });
+    }
+
+    /// <summary>
+    /// Modifier un arbre
+    /// </summary>
+    /// <param name="id">L'identifiant de l'érablière</param>
+    /// <param name="arbre">L'arbre à modifier</param>
+    /// <param name="token">Le token d'annulation</param>
+    /// <response code="204">L'arbre a été correctement modifié.</response>
+    /// <response code="400">La validation de l'arbre a échoué.</response>
+    [HttpPut]
+    [ValiderOwnership("id")]
+    public async Task<IActionResult> Modifier(Guid id, Arbre arbre, CancellationToken token)
+    {
+        if (id != arbre.IdErabliere)
+        {
+            return BadRequest("L'id de la route ne concorde pas avec l'id de l'arbre à modifier.");
+        }
+
+        if (!CoordonneesValides(arbre.Latitude, arbre.Longitude))
+        {
+            return BadRequest("L'arbre doit avoir une longitude entre -180 et 180 et une latitude entre -90 et 90.");
+        }
+
+        arbre.DM = DateTimeOffset.Now;
+
+        _depot.Update(arbre);
+
+        await _depot.SaveChangesAsync(token);
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Supprimer un arbre. Les entailles rattachées à l'arbre sont conservées,
+    /// mais leur lien vers l'arbre est retiré.
+    /// </summary>
+    /// <param name="id">Identifiant de l'érablière</param>
+    /// <param name="idArbre">Identifiant de l'arbre à supprimer</param>
+    /// <param name="token">Le token d'annulation</param>
+    /// <response code="204">L'arbre a été correctement supprimé.</response>
+    /// <response code="404">L'arbre n'existe pas ou n'appartient pas à l'érablière.</response>
+    [HttpDelete("{idArbre}")]
+    [ValiderOwnership("id")]
+    public async Task<IActionResult> Supprimer(Guid id, Guid idArbre, CancellationToken token)
+    {
+        var arbre = await _depot.Arbres.FindAsync([idArbre], token);
+
+        if (arbre == null || arbre.IdErabliere != id)
+        {
+            return NotFound();
+        }
+
+        var entailles = await _depot.Entailles
+            .Where(e => e.IdArbre == idArbre)
+            .ToListAsync(token);
+
+        foreach (var entaille in entailles)
+        {
+            entaille.IdArbre = null;
+        }
+
+        _depot.Remove(arbre);
+
+        await _depot.SaveChangesAsync(token);
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Valider qu'une paire latitude/longitude est dans les bornes valides
+    /// </summary>
+    internal static bool CoordonneesValides(double latitude, double longitude)
+    {
+        return latitude >= -90 && latitude <= 90 && longitude >= -180 && longitude <= 180;
+    }
+}

--- a/ErabliereApi/Controllers/BarilController.cs
+++ b/ErabliereApi/Controllers/BarilController.cs
@@ -1,6 +1,8 @@
 ﻿using ErabliereApi.Attributes;
 using ErabliereApi.Depot.Sql;
 using ErabliereApi.Donnees;
+using ErabliereApi.Donnees.Action.Post;
+using ErabliereApi.Donnees.Action.Put;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -54,14 +56,21 @@ public class BarilController : ControllerBase
     /// <response code="400">L'id de la route ne concorde pas avec l'id du baril à ajouter.</response>
     [HttpPost]
     [ValiderOwnership("id")]
-    public async Task<IActionResult> Ajouter(Guid id, Baril baril, CancellationToken token)
+    public async Task<IActionResult> Ajouter(Guid id, PostBaril baril, CancellationToken token)
     {
         if (id != baril.IdErabliere)
         {
             return BadRequest("L'id de la route ne concorde pas avec l'id du baril à ajouter");
         }
 
-        var entity = await _depot.Barils.AddAsync(baril, token);
+        var entity = await _depot.Barils.AddAsync(new Baril
+        {
+            Id = baril.Id,
+            IdErabliere = baril.IdErabliere,
+            DF = baril.DF,
+            QE = baril.QE,
+            Q = baril.Q
+        }, token);
 
         await _depot.SaveChangesAsync(token);
 
@@ -78,14 +87,28 @@ public class BarilController : ControllerBase
     /// <response code="400">L'id de la route ne concorde pas avec l'id du baril à modifier.</response>
     [HttpPut]
     [ValiderOwnership("id")]
-    public async Task<IActionResult> Modifier(Guid id, Baril baril, CancellationToken token)
+    public async Task<IActionResult> Modifier(Guid id, PutBaril baril, CancellationToken token)
     {
         if (id != baril.IdErabliere)
         {
             return BadRequest("L'id de la route ne concorde pas avec l'id du baril à modifier.");
         }
 
-        _depot.Update(baril);
+        if (baril.Id == null)
+        {
+            return BadRequest("L'id du baril à modifier est requis.");
+        }
+
+        var entity = await _depot.Barils.FindAsync([baril.Id], token);
+
+        if (entity == null || entity.IdErabliere != id)
+        {
+            return NotFound();
+        }
+
+        entity.DF = baril.DF;
+        entity.QE = baril.QE;
+        entity.Q = baril.Q;
 
         await _depot.SaveChangesAsync(token);
 

--- a/ErabliereApi/Controllers/DompeuxController.cs
+++ b/ErabliereApi/Controllers/DompeuxController.cs
@@ -2,6 +2,8 @@
 using ErabliereApi.Depot.Sql;
 using ErabliereApi.Donnees;
 using ErabliereApi.Donnees.Action.Get;
+using ErabliereApi.Donnees.Action.Post;
+using ErabliereApi.Donnees.Action.Put;
 using ErabliereApi.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -90,19 +92,28 @@ public class DompeuxController : ControllerBase
     [HttpPost]
     [ValiderIPRules]
     [ValiderOwnership("id")]
-    public async Task<IActionResult> Ajouter(Guid id, Dompeux dompeux)
+    public async Task<IActionResult> Ajouter(Guid id, PostDompeux dompeux)
     {
         if (id != dompeux.IdErabliere)
         {
             return BadRequest("L'id de la route ne concorde pas avec l'id du dompeux");
         }
 
-        if (dompeux.T == default || dompeux.T.Equals(DateTimeOffset.MinValue))
+        var t = dompeux.T;
+
+        if (t == default || t.Equals(DateTimeOffset.MinValue))
         {
-            dompeux.T = DateTimeOffset.Now;
+            t = DateTimeOffset.Now;
         }
 
-        var entity = await _context.Dompeux.AddAsync(dompeux);
+        var entity = await _context.Dompeux.AddAsync(new Dompeux
+        {
+            Id = dompeux.Id,
+            IdErabliere = dompeux.IdErabliere,
+            T = t,
+            DD = dompeux.DD,
+            DF = dompeux.DF
+        });
 
         await _context.SaveChangesAsync();
 
@@ -118,7 +129,7 @@ public class DompeuxController : ControllerBase
     [HttpPut("{idDompeux}")]
     [ValiderIPRules]
     [ValiderOwnership("id")]
-    public async Task<IActionResult> Modifier(Guid id, Guid idDompeux, Dompeux donnee)
+    public async Task<IActionResult> Modifier(Guid id, Guid idDompeux, PutDompeux donnee)
     {
         if (id != donnee.IdErabliere)
         {
@@ -129,7 +140,16 @@ public class DompeuxController : ControllerBase
             return BadRequest("L'id du dompeux de la route ne concorde pas avec l'id du dompeux");
         }
 
-        _context.Dompeux.Update(donnee);
+        var entity = await _context.Dompeux.FindAsync([idDompeux]);
+
+        if (entity == null || entity.IdErabliere != id)
+        {
+            return NotFound();
+        }
+
+        entity.T = donnee.T;
+        entity.DD = donnee.DD;
+        entity.DF = donnee.DF;
 
         await _context.SaveChangesAsync();
 

--- a/ErabliereApi/Controllers/DonneesCapteurController.cs
+++ b/ErabliereApi/Controllers/DonneesCapteurController.cs
@@ -1,6 +1,7 @@
 ﻿using ErabliereApi.Attributes;
 using ErabliereApi.Depot.Sql;
 using ErabliereApi.Donnees;
+using ErabliereApi.Donnees.Action.Put;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -36,14 +37,28 @@ public class DonneesCapteurController : ControllerBase
     /// <response code="400">L'id de la route ne concorde pas avec l'id du capteur à modifier.</response>
     [HttpPut]
     [ValiderOwnership("id", typeof(Capteur))]
-    public async Task<IActionResult> Modifier(Guid id, DonneeCapteur capteur, CancellationToken token)
+    public async Task<IActionResult> Modifier(Guid id, PutDonneeCapteur capteur, CancellationToken token)
     {
         if (id != capteur.IdCapteur)
         {
             return BadRequest("L'id de la route ne concorde pas avec l'id du capteur à modifier.");
         }
 
-        _depot.Update(capteur);
+        if (capteur.Id == null)
+        {
+            return BadRequest("L'id de la donnée à modifier est requis.");
+        }
+
+        var entity = await _depot.DonneesCapteur.FindAsync([capteur.Id], token);
+
+        if (entity == null || entity.IdCapteur != id)
+        {
+            return NotFound();
+        }
+
+        entity.Valeur = capteur.Valeur;
+        entity.Text = capteur.Text;
+        entity.D = capteur.D;
 
         await _depot.SaveChangesAsync(token);
 

--- a/ErabliereApi/Controllers/DonneesController.cs
+++ b/ErabliereApi/Controllers/DonneesController.cs
@@ -205,16 +205,16 @@ public class DonneesController : ControllerBase
     [ValiderIPRules]
     [ValiderOwnership("id")]
     [Route("Importer")]
-    public async Task<IActionResult> Importer(Guid id, Donnee[] donnees, CancellationToken token)
+    public async Task<IActionResult> Importer(Guid id, PostDonnee[] donnees, CancellationToken token)
     {
         await _context.AddRangeAsync(donnees.Select(d =>
         {
-            if (d.IdErabliere == null)
-            {
-                d.IdErabliere = id;
-            }
+            var donnee = d.MapTo<Donnee>();
 
-            return d;
+            // L'érablière est toujours celle de la route, jamais celle fournie dans le corps.
+            donnee.IdErabliere = id;
+
+            return donnee;
         }), cancellationToken: token);
 
         var nbStateEntrySaved = await _context.SaveChangesAsync(token);

--- a/ErabliereApi/Controllers/EntaillesController.cs
+++ b/ErabliereApi/Controllers/EntaillesController.cs
@@ -1,0 +1,170 @@
+using ErabliereApi.Attributes;
+using ErabliereApi.Depot.Sql;
+using ErabliereApi.Donnees;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.EntityFrameworkCore;
+
+namespace ErabliereApi.Controllers;
+
+/// <summary>
+/// Contrôler représentant les entailles cartographiées d'une érablière
+/// </summary>
+[ApiController]
+[Route("Erablieres/{id}/[controller]")]
+[Authorize]
+public class EntaillesController : ControllerBase
+{
+    private readonly ErabliereDbContext _depot;
+
+    /// <summary>
+    /// Constructeur par initialisation
+    /// </summary>
+    /// <param name="depot">Le dépôt des entailles</param>
+    public EntaillesController(ErabliereDbContext depot)
+    {
+        _depot = depot;
+    }
+
+    /// <summary>
+    /// Lister les entailles avec les fonctionnalités de OData
+    /// </summary>
+    /// <param name="id">Identifiant de l'érablière</param>
+    /// <response code="200">Une liste d'entailles potentiellement vide.</response>
+    [HttpGet]
+    [EnableQuery]
+    [ValiderOwnership("id")]
+    public IQueryable<Entaille> Lister(Guid id)
+    {
+        return _depot.Entailles.AsNoTracking().Where(e => e.IdErabliere == id);
+    }
+
+    /// <summary>
+    /// Ajouter une entaille
+    /// </summary>
+    /// <param name="id">L'identifiant de l'érablière</param>
+    /// <param name="entaille">L'entaille à ajouter</param>
+    /// <param name="token">Le token d'annulation</param>
+    /// <response code="200">L'entaille a été correctement ajoutée.</response>
+    /// <response code="400">La validation de l'entaille a échoué.</response>
+    [HttpPost]
+    [ValiderOwnership("id")]
+    public async Task<IActionResult> Ajouter(Guid id, Entaille entaille, CancellationToken token)
+    {
+        if (id != entaille.IdErabliere)
+        {
+            return BadRequest("L'id de la route ne concorde pas avec l'id de l'entaille à ajouter.");
+        }
+
+        var erreur = await ValiderEntaille(id, entaille, token);
+
+        if (erreur != null)
+        {
+            return BadRequest(erreur);
+        }
+
+        entaille.DC = DateTimeOffset.Now;
+        entaille.DM = DateTimeOffset.Now;
+
+        var entity = await _depot.Entailles.AddAsync(entaille, token);
+
+        await _depot.SaveChangesAsync(token);
+
+        return Ok(new { id = entity.Entity.Id });
+    }
+
+    /// <summary>
+    /// Modifier une entaille
+    /// </summary>
+    /// <param name="id">L'identifiant de l'érablière</param>
+    /// <param name="entaille">L'entaille à modifier</param>
+    /// <param name="token">Le token d'annulation</param>
+    /// <response code="204">L'entaille a été correctement modifiée.</response>
+    /// <response code="400">La validation de l'entaille a échoué.</response>
+    [HttpPut]
+    [ValiderOwnership("id")]
+    public async Task<IActionResult> Modifier(Guid id, Entaille entaille, CancellationToken token)
+    {
+        if (id != entaille.IdErabliere)
+        {
+            return BadRequest("L'id de la route ne concorde pas avec l'id de l'entaille à modifier.");
+        }
+
+        var erreur = await ValiderEntaille(id, entaille, token);
+
+        if (erreur != null)
+        {
+            return BadRequest(erreur);
+        }
+
+        entaille.DM = DateTimeOffset.Now;
+
+        _depot.Update(entaille);
+
+        await _depot.SaveChangesAsync(token);
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Supprimer une entaille
+    /// </summary>
+    /// <param name="id">Identifiant de l'érablière</param>
+    /// <param name="idEntaille">Identifiant de l'entaille à supprimer</param>
+    /// <param name="token">Le token d'annulation</param>
+    /// <response code="204">L'entaille a été correctement supprimée.</response>
+    /// <response code="404">L'entaille n'existe pas ou n'appartient pas à l'érablière.</response>
+    [HttpDelete("{idEntaille}")]
+    [ValiderOwnership("id")]
+    public async Task<IActionResult> Supprimer(Guid id, Guid idEntaille, CancellationToken token)
+    {
+        var entaille = await _depot.Entailles.FindAsync([idEntaille], token);
+
+        if (entaille == null || entaille.IdErabliere != id)
+        {
+            return NotFound();
+        }
+
+        _depot.Remove(entaille);
+
+        await _depot.SaveChangesAsync(token);
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Valider les coordonnées et les liens optionnels d'une entaille.
+    /// L'arbre et la ligne de tubelure référencés doivent exister et appartenir à la même érablière.
+    /// </summary>
+    /// <returns>Un message d'erreur, ou null si l'entaille est valide</returns>
+    private async Task<string?> ValiderEntaille(Guid id, Entaille entaille, CancellationToken token)
+    {
+        if (!ArbresController.CoordonneesValides(entaille.Latitude, entaille.Longitude))
+        {
+            return "L'entaille doit avoir une longitude entre -180 et 180 et une latitude entre -90 et 90.";
+        }
+
+        if (entaille.IdArbre != null)
+        {
+            var arbre = await _depot.Arbres.FindAsync([entaille.IdArbre], token);
+
+            if (arbre == null || arbre.IdErabliere != id)
+            {
+                return "L'arbre référencé n'existe pas ou n'appartient pas à l'érablière.";
+            }
+        }
+
+        if (entaille.IdLigneTubelure != null)
+        {
+            var ligne = await _depot.LignesTubelure.FindAsync([entaille.IdLigneTubelure], token);
+
+            if (ligne == null || ligne.IdErabliere != id)
+            {
+                return "La ligne de tubelure référencée n'existe pas ou n'appartient pas à l'érablière.";
+            }
+        }
+
+        return null;
+    }
+}

--- a/ErabliereApi/Controllers/EntaillesController.cs
+++ b/ErabliereApi/Controllers/EntaillesController.cs
@@ -1,6 +1,8 @@
 using ErabliereApi.Attributes;
 using ErabliereApi.Depot.Sql;
 using ErabliereApi.Donnees;
+using ErabliereApi.Donnees.Action.Post;
+using ErabliereApi.Donnees.Action.Put;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OData.Query;
@@ -50,24 +52,32 @@ public class EntaillesController : ControllerBase
     /// <response code="400">La validation de l'entaille a échoué.</response>
     [HttpPost]
     [ValiderOwnership("id")]
-    public async Task<IActionResult> Ajouter(Guid id, Entaille entaille, CancellationToken token)
+    public async Task<IActionResult> Ajouter(Guid id, PostEntaille entaille, CancellationToken token)
     {
         if (id != entaille.IdErabliere)
         {
             return BadRequest("L'id de la route ne concorde pas avec l'id de l'entaille à ajouter.");
         }
 
-        var erreur = await ValiderEntaille(id, entaille, token);
+        var erreur = await ValiderEntaille(id, entaille.Latitude, entaille.Longitude, entaille.IdArbre, entaille.IdLigneTubelure, token);
 
         if (erreur != null)
         {
             return BadRequest(erreur);
         }
 
-        entaille.DC = DateTimeOffset.Now;
-        entaille.DM = DateTimeOffset.Now;
-
-        var entity = await _depot.Entailles.AddAsync(entaille, token);
+        var entity = await _depot.Entailles.AddAsync(new Entaille
+        {
+            Id = entaille.Id,
+            IdErabliere = entaille.IdErabliere,
+            Nom = entaille.Nom,
+            Latitude = entaille.Latitude,
+            Longitude = entaille.Longitude,
+            IdArbre = entaille.IdArbre,
+            IdLigneTubelure = entaille.IdLigneTubelure,
+            DC = DateTimeOffset.Now,
+            DM = DateTimeOffset.Now
+        }, token);
 
         await _depot.SaveChangesAsync(token);
 
@@ -84,23 +94,38 @@ public class EntaillesController : ControllerBase
     /// <response code="400">La validation de l'entaille a échoué.</response>
     [HttpPut]
     [ValiderOwnership("id")]
-    public async Task<IActionResult> Modifier(Guid id, Entaille entaille, CancellationToken token)
+    public async Task<IActionResult> Modifier(Guid id, PutEntaille entaille, CancellationToken token)
     {
         if (id != entaille.IdErabliere)
         {
             return BadRequest("L'id de la route ne concorde pas avec l'id de l'entaille à modifier.");
         }
 
-        var erreur = await ValiderEntaille(id, entaille, token);
+        if (entaille.Id == null)
+        {
+            return BadRequest("L'id de l'entaille à modifier est requis.");
+        }
+
+        var erreur = await ValiderEntaille(id, entaille.Latitude, entaille.Longitude, entaille.IdArbre, entaille.IdLigneTubelure, token);
 
         if (erreur != null)
         {
             return BadRequest(erreur);
         }
 
-        entaille.DM = DateTimeOffset.Now;
+        var entity = await _depot.Entailles.FindAsync([entaille.Id], token);
 
-        _depot.Update(entaille);
+        if (entity == null || entity.IdErabliere != id)
+        {
+            return NotFound();
+        }
+
+        entity.Nom = entaille.Nom;
+        entity.Latitude = entaille.Latitude;
+        entity.Longitude = entaille.Longitude;
+        entity.IdArbre = entaille.IdArbre;
+        entity.IdLigneTubelure = entaille.IdLigneTubelure;
+        entity.DM = DateTimeOffset.Now;
 
         await _depot.SaveChangesAsync(token);
 
@@ -138,16 +163,16 @@ public class EntaillesController : ControllerBase
     /// L'arbre et la ligne de tubelure référencés doivent exister et appartenir à la même érablière.
     /// </summary>
     /// <returns>Un message d'erreur, ou null si l'entaille est valide</returns>
-    private async Task<string?> ValiderEntaille(Guid id, Entaille entaille, CancellationToken token)
+    private async Task<string?> ValiderEntaille(Guid id, double latitude, double longitude, Guid? idArbre, Guid? idLigneTubelure, CancellationToken token)
     {
-        if (!ArbresController.CoordonneesValides(entaille.Latitude, entaille.Longitude))
+        if (!ArbresController.CoordonneesValides(latitude, longitude))
         {
             return "L'entaille doit avoir une longitude entre -180 et 180 et une latitude entre -90 et 90.";
         }
 
-        if (entaille.IdArbre != null)
+        if (idArbre != null)
         {
-            var arbre = await _depot.Arbres.FindAsync([entaille.IdArbre], token);
+            var arbre = await _depot.Arbres.FindAsync([idArbre], token);
 
             if (arbre == null || arbre.IdErabliere != id)
             {
@@ -155,9 +180,9 @@ public class EntaillesController : ControllerBase
             }
         }
 
-        if (entaille.IdLigneTubelure != null)
+        if (idLigneTubelure != null)
         {
-            var ligne = await _depot.LignesTubelure.FindAsync([entaille.IdLigneTubelure], token);
+            var ligne = await _depot.LignesTubelure.FindAsync([idLigneTubelure], token);
 
             if (ligne == null || ligne.IdErabliere != id)
             {

--- a/ErabliereApi/Controllers/LignesTubelureController.cs
+++ b/ErabliereApi/Controllers/LignesTubelureController.cs
@@ -1,0 +1,207 @@
+using ErabliereApi.Attributes;
+using ErabliereApi.Depot.Sql;
+using ErabliereApi.Donnees;
+using ErabliereApi.Donnees.Contantes;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.EntityFrameworkCore;
+using System.Text.Json;
+
+namespace ErabliereApi.Controllers;
+
+/// <summary>
+/// Contrôler représentant les lignes du réseau de tubelure
+/// </summary>
+[ApiController]
+[Route("Erablieres/{id}/[controller]")]
+[Authorize]
+public class LignesTubelureController : ControllerBase
+{
+    private readonly ErabliereDbContext _depot;
+
+    /// <summary>
+    /// Nombre maximal de points d'une ligne de tubelure
+    /// </summary>
+    public const int MaxPoints = 10000;
+
+    /// <summary>
+    /// Constructeur par initialisation
+    /// </summary>
+    /// <param name="depot">Le dépôt des lignes de tubelure</param>
+    public LignesTubelureController(ErabliereDbContext depot)
+    {
+        _depot = depot;
+    }
+
+    /// <summary>
+    /// Lister les lignes de tubelure avec les fonctionnalités de OData
+    /// </summary>
+    /// <param name="id">Identifiant de l'érablière</param>
+    /// <response code="200">Une liste de lignes de tubelure potentiellement vide.</response>
+    [HttpGet]
+    [EnableQuery]
+    [ValiderOwnership("id")]
+    public IQueryable<LigneTubelure> Lister(Guid id)
+    {
+        return _depot.LignesTubelure.AsNoTracking().Where(l => l.IdErabliere == id);
+    }
+
+    /// <summary>
+    /// Ajouter une ligne de tubelure
+    /// </summary>
+    /// <param name="id">L'identifiant de l'érablière</param>
+    /// <param name="ligne">La ligne à ajouter</param>
+    /// <param name="token">Le token d'annulation</param>
+    /// <response code="200">La ligne a été correctement ajoutée.</response>
+    /// <response code="400">La validation de la ligne a échoué.</response>
+    [HttpPost]
+    [ValiderOwnership("id")]
+    public async Task<IActionResult> Ajouter(Guid id, LigneTubelure ligne, CancellationToken token)
+    {
+        if (id != ligne.IdErabliere)
+        {
+            return BadRequest("L'id de la route ne concorde pas avec l'id de la ligne à ajouter.");
+        }
+
+        var erreur = ValiderLigne(ligne);
+
+        if (erreur != null)
+        {
+            return BadRequest(erreur);
+        }
+
+        ligne.TypeLigne = ligne.TypeLigne?.ToLowerInvariant();
+        ligne.DC = DateTimeOffset.Now;
+        ligne.DM = DateTimeOffset.Now;
+
+        var entity = await _depot.LignesTubelure.AddAsync(ligne, token);
+
+        await _depot.SaveChangesAsync(token);
+
+        return Ok(new { id = entity.Entity.Id });
+    }
+
+    /// <summary>
+    /// Modifier une ligne de tubelure
+    /// </summary>
+    /// <param name="id">L'identifiant de l'érablière</param>
+    /// <param name="ligne">La ligne à modifier</param>
+    /// <param name="token">Le token d'annulation</param>
+    /// <response code="204">La ligne a été correctement modifiée.</response>
+    /// <response code="400">La validation de la ligne a échoué.</response>
+    [HttpPut]
+    [ValiderOwnership("id")]
+    public async Task<IActionResult> Modifier(Guid id, LigneTubelure ligne, CancellationToken token)
+    {
+        if (id != ligne.IdErabliere)
+        {
+            return BadRequest("L'id de la route ne concorde pas avec l'id de la ligne à modifier.");
+        }
+
+        var erreur = ValiderLigne(ligne);
+
+        if (erreur != null)
+        {
+            return BadRequest(erreur);
+        }
+
+        ligne.TypeLigne = ligne.TypeLigne?.ToLowerInvariant();
+        ligne.DM = DateTimeOffset.Now;
+
+        _depot.Update(ligne);
+
+        await _depot.SaveChangesAsync(token);
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Supprimer une ligne de tubelure. Les entailles raccordées à la ligne sont conservées,
+    /// mais leur lien vers la ligne est retiré.
+    /// </summary>
+    /// <param name="id">Identifiant de l'érablière</param>
+    /// <param name="idLigne">Identifiant de la ligne à supprimer</param>
+    /// <param name="token">Le token d'annulation</param>
+    /// <response code="204">La ligne a été correctement supprimée.</response>
+    /// <response code="404">La ligne n'existe pas ou n'appartient pas à l'érablière.</response>
+    [HttpDelete("{idLigne}")]
+    [ValiderOwnership("id")]
+    public async Task<IActionResult> Supprimer(Guid id, Guid idLigne, CancellationToken token)
+    {
+        var ligne = await _depot.LignesTubelure.FindAsync([idLigne], token);
+
+        if (ligne == null || ligne.IdErabliere != id)
+        {
+            return NotFound();
+        }
+
+        var entailles = await _depot.Entailles
+            .Where(e => e.IdLigneTubelure == idLigne)
+            .ToListAsync(token);
+
+        foreach (var entaille in entailles)
+        {
+            entaille.IdLigneTubelure = null;
+        }
+
+        _depot.Remove(ligne);
+
+        await _depot.SaveChangesAsync(token);
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Valider le type et les coordonnées d'une ligne de tubelure.
+    /// </summary>
+    /// <returns>Un message d'erreur, ou null si la ligne est valide</returns>
+    internal static string? ValiderLigne(LigneTubelure ligne)
+    {
+        if (!TypeLigneTubelure.EstValide(ligne.TypeLigne))
+        {
+            return $"Le type de ligne doit être une des valeurs suivantes : {string.Join(", ", TypeLigneTubelure.Tous)}.";
+        }
+
+        if (string.IsNullOrWhiteSpace(ligne.CoordonneesJson))
+        {
+            return "Les coordonnées de la ligne sont requises.";
+        }
+
+        double[][]? coordonnees;
+
+        try
+        {
+            coordonnees = JsonSerializer.Deserialize<double[][]>(ligne.CoordonneesJson);
+        }
+        catch (JsonException)
+        {
+            return "Les coordonnées de la ligne doivent être un tableau JSON de paires [longitude, latitude].";
+        }
+
+        if (coordonnees == null || coordonnees.Length < 2)
+        {
+            return "Une ligne de tubelure doit contenir au moins 2 points.";
+        }
+
+        if (coordonnees.Length > MaxPoints)
+        {
+            return $"Une ligne de tubelure ne peut pas contenir plus de {MaxPoints} points.";
+        }
+
+        foreach (var point in coordonnees)
+        {
+            if (point == null || point.Length != 2)
+            {
+                return "Chaque point de la ligne doit être une paire [longitude, latitude].";
+            }
+
+            if (point[0] < -180 || point[0] > 180 || point[1] < -90 || point[1] > 90)
+            {
+                return "Chaque point doit avoir une longitude entre -180 et 180 et une latitude entre -90 et 90.";
+            }
+        }
+
+        return null;
+    }
+}

--- a/ErabliereApi/Controllers/LignesTubelureController.cs
+++ b/ErabliereApi/Controllers/LignesTubelureController.cs
@@ -1,6 +1,8 @@
 using ErabliereApi.Attributes;
 using ErabliereApi.Depot.Sql;
 using ErabliereApi.Donnees;
+using ErabliereApi.Donnees.Action.Post;
+using ErabliereApi.Donnees.Action.Put;
 using ErabliereApi.Donnees.Contantes;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -57,25 +59,30 @@ public class LignesTubelureController : ControllerBase
     /// <response code="400">La validation de la ligne a échoué.</response>
     [HttpPost]
     [ValiderOwnership("id")]
-    public async Task<IActionResult> Ajouter(Guid id, LigneTubelure ligne, CancellationToken token)
+    public async Task<IActionResult> Ajouter(Guid id, PostLigneTubelure ligne, CancellationToken token)
     {
         if (id != ligne.IdErabliere)
         {
             return BadRequest("L'id de la route ne concorde pas avec l'id de la ligne à ajouter.");
         }
 
-        var erreur = ValiderLigne(ligne);
+        var erreur = ValiderLigne(ligne.TypeLigne, ligne.CoordonneesJson);
 
         if (erreur != null)
         {
             return BadRequest(erreur);
         }
 
-        ligne.TypeLigne = ligne.TypeLigne?.ToLowerInvariant();
-        ligne.DC = DateTimeOffset.Now;
-        ligne.DM = DateTimeOffset.Now;
-
-        var entity = await _depot.LignesTubelure.AddAsync(ligne, token);
+        var entity = await _depot.LignesTubelure.AddAsync(new LigneTubelure
+        {
+            Id = ligne.Id,
+            IdErabliere = ligne.IdErabliere,
+            Nom = ligne.Nom,
+            TypeLigne = ligne.TypeLigne?.ToLowerInvariant(),
+            CoordonneesJson = ligne.CoordonneesJson,
+            DC = DateTimeOffset.Now,
+            DM = DateTimeOffset.Now
+        }, token);
 
         await _depot.SaveChangesAsync(token);
 
@@ -92,24 +99,36 @@ public class LignesTubelureController : ControllerBase
     /// <response code="400">La validation de la ligne a échoué.</response>
     [HttpPut]
     [ValiderOwnership("id")]
-    public async Task<IActionResult> Modifier(Guid id, LigneTubelure ligne, CancellationToken token)
+    public async Task<IActionResult> Modifier(Guid id, PutLigneTubelure ligne, CancellationToken token)
     {
         if (id != ligne.IdErabliere)
         {
             return BadRequest("L'id de la route ne concorde pas avec l'id de la ligne à modifier.");
         }
 
-        var erreur = ValiderLigne(ligne);
+        if (ligne.Id == null)
+        {
+            return BadRequest("L'id de la ligne à modifier est requis.");
+        }
+
+        var erreur = ValiderLigne(ligne.TypeLigne, ligne.CoordonneesJson);
 
         if (erreur != null)
         {
             return BadRequest(erreur);
         }
 
-        ligne.TypeLigne = ligne.TypeLigne?.ToLowerInvariant();
-        ligne.DM = DateTimeOffset.Now;
+        var entity = await _depot.LignesTubelure.FindAsync([ligne.Id], token);
 
-        _depot.Update(ligne);
+        if (entity == null || entity.IdErabliere != id)
+        {
+            return NotFound();
+        }
+
+        entity.Nom = ligne.Nom;
+        entity.TypeLigne = ligne.TypeLigne?.ToLowerInvariant();
+        entity.CoordonneesJson = ligne.CoordonneesJson;
+        entity.DM = DateTimeOffset.Now;
 
         await _depot.SaveChangesAsync(token);
 
@@ -156,14 +175,14 @@ public class LignesTubelureController : ControllerBase
     /// Valider le type et les coordonnées d'une ligne de tubelure.
     /// </summary>
     /// <returns>Un message d'erreur, ou null si la ligne est valide</returns>
-    internal static string? ValiderLigne(LigneTubelure ligne)
+    internal static string? ValiderLigne(string? typeLigne, string? coordonneesJson)
     {
-        if (!TypeLigneTubelure.EstValide(ligne.TypeLigne))
+        if (!TypeLigneTubelure.EstValide(typeLigne))
         {
             return $"Le type de ligne doit être une des valeurs suivantes : {string.Join(", ", TypeLigneTubelure.Tous)}.";
         }
 
-        if (string.IsNullOrWhiteSpace(ligne.CoordonneesJson))
+        if (string.IsNullOrWhiteSpace(coordonneesJson))
         {
             return "Les coordonnées de la ligne sont requises.";
         }
@@ -172,7 +191,7 @@ public class LignesTubelureController : ControllerBase
 
         try
         {
-            coordonnees = JsonSerializer.Deserialize<double[][]>(ligne.CoordonneesJson);
+            coordonnees = JsonSerializer.Deserialize<double[][]>(coordonneesJson);
         }
         catch (JsonException)
         {

--- a/ErabliereApi/Controllers/TubelureController.cs
+++ b/ErabliereApi/Controllers/TubelureController.cs
@@ -1,0 +1,140 @@
+using ErabliereApi.Attributes;
+using ErabliereApi.Depot.Sql;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Text.Json;
+
+namespace ErabliereApi.Controllers;
+
+/// <summary>
+/// Contrôler permettant d'obtenir le réseau de tubelure complet d'une érablière
+/// (lignes, arbres et entailles) sous format GeoJson
+/// </summary>
+[ApiController]
+[Route("Erablieres/{id}/[controller]")]
+[Authorize]
+public class TubelureController : ControllerBase
+{
+    private readonly ErabliereDbContext _depot;
+    private readonly ILogger<TubelureController> _logger;
+
+    /// <summary>
+    /// Constructeur par initialisation
+    /// </summary>
+    /// <param name="depot">Le dépôt des données</param>
+    /// <param name="logger">Le logger</param>
+    public TubelureController(ErabliereDbContext depot, ILogger<TubelureController> logger)
+    {
+        _depot = depot;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Obtenir le réseau de tubelure de l'érablière sous format GeoJson.
+    /// Les lignes sont des features LineString, les arbres et les entailles des features Point.
+    /// </summary>
+    /// <param name="id">Identifiant de l'érablière</param>
+    /// <param name="token">Le token d'annulation</param>
+    /// <response code="200">Une FeatureCollection GeoJson.</response>
+    [HttpGet("GeoJson")]
+    [ValiderOwnership("id")]
+    public async Task<IActionResult> GetGeoJson(Guid id, CancellationToken token)
+    {
+        var lignes = await _depot.LignesTubelure.AsNoTracking()
+            .Where(l => l.IdErabliere == id)
+            .ToArrayAsync(token);
+
+        var arbres = await _depot.Arbres.AsNoTracking()
+            .Where(a => a.IdErabliere == id)
+            .ToArrayAsync(token);
+
+        var entailles = await _depot.Entailles.AsNoTracking()
+            .Where(e => e.IdErabliere == id)
+            .ToArrayAsync(token);
+
+        var features = new List<object>();
+
+        foreach (var ligne in lignes)
+        {
+            double[][]? coordonnees = null;
+
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(ligne.CoordonneesJson))
+                {
+                    coordonnees = JsonSerializer.Deserialize<double[][]>(ligne.CoordonneesJson);
+                }
+            }
+            catch (JsonException e)
+            {
+                _logger.LogWarning(e, "Les coordonnées de la ligne de tubelure {IdLigne} sont invalides, la ligne est ignorée du GeoJson.", ligne.Id);
+            }
+
+            if (coordonnees == null || coordonnees.Length < 2)
+            {
+                continue;
+            }
+
+            features.Add(new
+            {
+                type = "Feature",
+                geometry = new
+                {
+                    type = "LineString",
+                    coordinates = coordonnees
+                },
+                properties = new
+                {
+                    id = ligne.Id,
+                    nom = ligne.Nom,
+                    typeLigne = ligne.TypeLigne,
+                    feature = "ligne"
+                }
+            });
+        }
+
+        features.AddRange(arbres.Select(arbre => (object)new
+        {
+            type = "Feature",
+            geometry = new
+            {
+                type = "Point",
+                coordinates = new[] { arbre.Longitude, arbre.Latitude }
+            },
+            properties = new
+            {
+                id = arbre.Id,
+                nom = arbre.Nom,
+                espece = arbre.Espece,
+                feature = "arbre"
+            }
+        }));
+
+        features.AddRange(entailles.Select(entaille => (object)new
+        {
+            type = "Feature",
+            geometry = new
+            {
+                type = "Point",
+                coordinates = new[] { entaille.Longitude, entaille.Latitude }
+            },
+            properties = new
+            {
+                id = entaille.Id,
+                nom = entaille.Nom,
+                idArbre = entaille.IdArbre,
+                idLigneTubelure = entaille.IdLigneTubelure,
+                feature = "entaille"
+            }
+        }));
+
+        var geoJson = new
+        {
+            type = "FeatureCollection",
+            features = features.ToArray()
+        };
+
+        return Ok(geoJson);
+    }
+}

--- a/ErabliereApi/Depot/Sql/EntityConfiguration/EntailleEntityConfiguration.cs
+++ b/ErabliereApi/Depot/Sql/EntityConfiguration/EntailleEntityConfiguration.cs
@@ -1,0 +1,32 @@
+using ErabliereApi.Donnees;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace ErabliereApi.Depot.Sql.EntityConfiguration;
+
+/// <summary>
+/// Configuration de la table <see cref="ErabliereDbContext.Entailles" />
+/// </summary>
+public class EntailleEntityConfiguration : IEntityTypeConfiguration<Entaille>
+{
+    /// <inheritdoc />
+    /// <remarks>
+    /// Les relations optionnelles vers l'arbre et la ligne de tubelure utilisent
+    /// ClientSetNull pour éviter les chemins de cascade multiples refusés par SQL Server
+    /// (Erabliere -> Entaille en cascade et Erabliere -> Arbre -> Entaille). Les contrôleurs
+    /// doivent mettre à null les clés étrangères des entailles dépendantes avant de
+    /// supprimer un arbre ou une ligne.
+    /// </remarks>
+    public void Configure(EntityTypeBuilder<Entaille> entaille)
+    {
+        entaille.HasOne(e => e.Arbre)
+                .WithMany(a => a.Entailles)
+                .HasForeignKey(e => e.IdArbre)
+                .OnDelete(DeleteBehavior.ClientSetNull);
+
+        entaille.HasOne(e => e.LigneTubelure)
+                .WithMany(l => l.Entailles)
+                .HasForeignKey(e => e.IdLigneTubelure)
+                .OnDelete(DeleteBehavior.ClientSetNull);
+    }
+}

--- a/ErabliereApi/Depot/Sql/EntityConfiguration/ErabliereEntityConfiguration.cs
+++ b/ErabliereApi/Depot/Sql/EntityConfiguration/ErabliereEntityConfiguration.cs
@@ -62,5 +62,20 @@ public class ErabliereEntityConfiguration : IEntityTypeConfiguration<Erabliere>
         erabliere.HasMany(u => u.Horaires)
                  .WithOne(a => a.Erabliere)
                  .HasForeignKey(a => a.IdErabliere);
+
+        erabliere.HasMany(e => e.LignesTubelure)
+                 .WithOne(l => l.Erabliere)
+                 .HasForeignKey(l => l.IdErabliere)
+                 .OnDelete(DeleteBehavior.Cascade);
+
+        erabliere.HasMany(e => e.Arbres)
+                 .WithOne(a => a.Erabliere)
+                 .HasForeignKey(a => a.IdErabliere)
+                 .OnDelete(DeleteBehavior.Cascade);
+
+        erabliere.HasMany(e => e.Entailles)
+                 .WithOne(e => e.Erabliere)
+                 .HasForeignKey(e => e.IdErabliere)
+                 .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/ErabliereApi/Depot/Sql/ErabliereDbContext.cs
+++ b/ErabliereApi/Depot/Sql/ErabliereDbContext.cs
@@ -153,6 +153,21 @@ namespace ErabliereApi.Depot.Sql
         /// </summary>
         public DbSet<ChirpStackMessage> ChirpstackMessageHistory { get; private set; }
 
+        /// <summary>
+        /// Table des lignes du réseau de tubelure
+        /// </summary>
+        public DbSet<LigneTubelure> LignesTubelure { get; private set; }
+
+        /// <summary>
+        /// Table des arbres cartographiés
+        /// </summary>
+        public DbSet<Arbre> Arbres { get; private set; }
+
+        /// <summary>
+        /// Table des entailles cartographiées
+        /// </summary>
+        public DbSet<Entaille> Entailles { get; private set; }
+
 #pragma warning restore S1144 // Unused private types or members should be removed
 
         /// <inheritdoc />

--- a/ErabliereApi/Depot/Sql/Migrations/20260712154801_AjoutTubelure.Designer.cs
+++ b/ErabliereApi/Depot/Sql/Migrations/20260712154801_AjoutTubelure.Designer.cs
@@ -4,6 +4,7 @@ using ErabliereApi.Depot.Sql;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Depot.Sql.Migrations
 {
     [DbContext(typeof(ErabliereDbContext))]
-    partial class ErabliereDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260712154801_AjoutTubelure")]
+    partial class AjoutTubelure
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ErabliereApi/Depot/Sql/Migrations/20260712154801_AjoutTubelure.cs
+++ b/ErabliereApi/Depot/Sql/Migrations/20260712154801_AjoutTubelure.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Depot.Sql.Migrations
+{
+    /// <inheritdoc />
+    public partial class AjoutTubelure : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Arbres",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    IdErabliere = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    Nom = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true),
+                    Espece = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    Latitude = table.Column<double>(type: "float", nullable: false),
+                    Longitude = table.Column<double>(type: "float", nullable: false),
+                    DC = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    DM = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Arbres", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Arbres_Erabliere_IdErabliere",
+                        column: x => x.IdErabliere,
+                        principalTable: "Erabliere",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LignesTubelure",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    IdErabliere = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    Nom = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true),
+                    TypeLigne = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: true),
+                    CoordonneesJson = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    DC = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    DM = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LignesTubelure", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_LignesTubelure_Erabliere_IdErabliere",
+                        column: x => x.IdErabliere,
+                        principalTable: "Erabliere",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Entailles",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    IdErabliere = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    Nom = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true),
+                    Latitude = table.Column<double>(type: "float", nullable: false),
+                    Longitude = table.Column<double>(type: "float", nullable: false),
+                    IdArbre = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IdLigneTubelure = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    DC = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    DM = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Entailles", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Entailles_Arbres_IdArbre",
+                        column: x => x.IdArbre,
+                        principalTable: "Arbres",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_Entailles_Erabliere_IdErabliere",
+                        column: x => x.IdErabliere,
+                        principalTable: "Erabliere",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Entailles_LignesTubelure_IdLigneTubelure",
+                        column: x => x.IdLigneTubelure,
+                        principalTable: "LignesTubelure",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Arbres_IdErabliere",
+                table: "Arbres",
+                column: "IdErabliere");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Entailles_IdArbre",
+                table: "Entailles",
+                column: "IdArbre");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Entailles_IdErabliere",
+                table: "Entailles",
+                column: "IdErabliere");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Entailles_IdLigneTubelure",
+                table: "Entailles",
+                column: "IdLigneTubelure");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LignesTubelure_IdErabliere",
+                table: "LignesTubelure",
+                column: "IdErabliere");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Entailles");
+
+            migrationBuilder.DropTable(
+                name: "Arbres");
+
+            migrationBuilder.DropTable(
+                name: "LignesTubelure");
+        }
+    }
+}

--- a/ErabliereIU/CLAUDE.md
+++ b/ErabliereIU/CLAUDE.md
@@ -35,6 +35,8 @@ Auth is abstracted behind `IAuthorisationSerivce` and resolved at runtime by `Au
 
 MSAL is wired in `src/app/app.config.ts` (`MSALInstanceFactory`, `MSALInterceptorConfigFactory`) using the runtime `EnvironmentService`. Never call MSAL directly from features — go through `AuthorisationFactoryService.getAuthorisationService()`. Route guards (`src/app/guard/`) do the same: `AdminGuard` checks the `administrateur` role, `AuthenticatedUserGard` checks login.
 
+Since Angular 22, components whose data loads are triggered by MSAL events/subscriptions (outside Angular's notification zone) must set `ChangeDetectionStrategy.Eager`, otherwise the view silently never updates after data arrives.
+
 ### Central data access: `ErabliereApi` service
 
 `src/core/erabliereapi.service.ts` is the single large service wrapping all backend calls. It builds **OData** query strings by hand (`$filter`, `$expand`, `$orderby`) against `EnvironmentService.apiUrl` and attaches auth headers from the resolved auth service. The API uses custom `x-ddr` / `x-dde` HTTP headers to minimize transferred data (delta ranges) — search the repo for these when touching data-fetch optimization. New backend endpoints are added as methods here.

--- a/ErabliereIU/src/app/app.routes.ts
+++ b/ErabliereIU/src/app/app.routes.ts
@@ -12,6 +12,7 @@ import { AdminViewComponent } from "./admin-view/admin-view.component";
 import { AdminErablieresComponent } from "src/app/admin-view/admin-erablieres/admin-erablieres.component";
 import { ClientViewComponent } from "./client-view/client-view.component";
 import { GestionCapteursComponent } from "src/app/client-view/capteurs/gestion-capteurs.component";
+import { TubelureComponent } from "src/app/client-view/tubelure/tubelure.component";
 import { ReportsComponent } from 'src/app/client-view/rapport/rapports.component';
 import { AdminAPIKeysComponent } from 'src/app/admin-view/admin-apikeys/admin-apikeys.component';
 import { MapViewComponent } from './map-view/map-view.component';
@@ -175,6 +176,11 @@ export const routes: Routes = [
                 path: 'e/:idErabliereSelectionee/rapports',
                 title: 'ÉrablièreIU - Rapports',
                 component: ReportsComponent
+            },
+            {
+                path: 'e/:idErabliereSelectionee/tubelure',
+                title: 'ÉrablièreIU - Tubelure',
+                component: TubelureComponent
             },
             {
                 path: 'apropos',

--- a/ErabliereIU/src/app/client-view/client-nav-bar/client-nav-bar.component.html
+++ b/ErabliereIU/src/app/client-view/client-nav-bar/client-nav-bar.component.html
@@ -57,6 +57,14 @@
                         Rapports
                     </a>
                 </li>
+                @if (mapFeatureEnable) {
+                <li class="nav-item">
+                    <a class="nav-link" routerLink="/e/{{idErabliereSelectionee}}/tubelure" routerLinkActive="active"
+                        ariaCurrentWhenActive="page">
+                        Tubelure
+                    </a>
+                </li>
+                }
                 }
                 <li class="nav-item">
                     <a class="nav-link" routerLink="/apropos" routerLinkActive="active" ariaCurrentWhenActive="page">

--- a/ErabliereIU/src/app/client-view/tubelure/tubelure.component.css
+++ b/ErabliereIU/src/app/client-view/tubelure/tubelure.component.css
@@ -1,0 +1,74 @@
+.carte-wrapper {
+    position: relative;
+    height: calc(100dvh - 160px);
+    min-height: 400px;
+}
+
+#map-tubelure {
+    position: absolute;
+    inset: 0;
+}
+
+.toolbar {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 10;
+    background: rgba(255, 255, 255, 0.9);
+}
+
+.toolbar .btn {
+    min-height: 48px;
+}
+
+.nom-ligne {
+    max-width: 250px;
+}
+
+.legende {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 10;
+    font-size: 0.85rem;
+    opacity: 0.92;
+}
+
+.legende .trait {
+    display: inline-block;
+    width: 22px;
+    height: 4px;
+    border-radius: 2px;
+    vertical-align: middle;
+    margin-right: 4px;
+}
+
+.legende .pastille {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    border: 2px solid #fff;
+    vertical-align: middle;
+    margin-right: 4px;
+}
+
+.badge-gps {
+    position: absolute;
+    top: 10px;
+    right: 50px;
+    z-index: 10;
+}
+
+.chargement {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 10;
+}
+
+.mapboxgl-popup {
+    max-width: 300px;
+}

--- a/ErabliereIU/src/app/client-view/tubelure/tubelure.component.html
+++ b/ErabliereIU/src/app/client-view/tubelure/tubelure.component.html
@@ -33,7 +33,7 @@
 
         @if (loadingInProgress) {
         <div class="chargement">
-            <div class="spinner-border text-primary" role="status">
+            <div class="spinner-border text-primary">
                 <span class="visually-hidden">Chargement...</span>
             </div>
         </div>
@@ -65,11 +65,11 @@
             }
             @else if (mode === 'ligne') {
             <div class="d-flex gap-2 flex-wrap align-items-center mb-2">
-                <span class="badge fs-6 text-white" [style.background]="couleursLigne[typeLigneEnCours]">
+                <label for="nomLigne" class="badge fs-6 text-white" [style.background]="couleursLigne[typeLigneEnCours]">
                     {{ libellesLigne[typeLigneEnCours] }} — {{ pointsEnCours.length }} point(s)
-                </span>
+                </label>
                 <input type="text" class="form-control form-control-lg nom-ligne" placeholder="Nom de la ligne (ex: M-01)"
-                    [(ngModel)]="nomLigneEnCours" name="nomLigne" />
+                    [(ngModel)]="nomLigneEnCours" name="nomLigne" id="nomLigne" />
             </div>
             <div class="d-flex gap-2 flex-wrap">
                 <button type="button" class="btn btn-primary btn-lg" (click)="ajouterPointGps()" [disabled]="!gpsFix"

--- a/ErabliereIU/src/app/client-view/tubelure/tubelure.component.html
+++ b/ErabliereIU/src/app/client-view/tubelure/tubelure.component.html
@@ -1,0 +1,203 @@
+<div class="border-top">
+    @if (error) {
+    <div class="alert alert-danger alert-dismissible m-2 mb-0" role="alert">
+        {{ error }}
+        <button type="button" class="btn-close" aria-label="Fermer" (click)="error = undefined"></button>
+    </div>
+    }
+    @if (erreurGps) {
+    <div class="alert alert-warning alert-dismissible m-2 mb-0" role="alert">
+        {{ erreurGps }}
+        <button type="button" class="btn-close" aria-label="Fermer" (click)="erreurGps = undefined"></button>
+    </div>
+    }
+
+    <div class="carte-wrapper">
+        <div id="map-tubelure"></div>
+
+        <div class="legende card p-2">
+            <strong>Légende</strong>
+            @for (type of typesLigne; track type) {
+            <span><span class="trait" [style.background]="couleursLigne[type]"></span> {{ libellesLigne[type] }}</span>
+            }
+            <span><span class="pastille" style="background: #2ca02c;"></span> Arbre</span>
+            <span><span class="pastille" style="background: #8c564b;"></span> Entaille</span>
+        </div>
+
+        @if (gpsFix) {
+        <span class="badge badge-gps" [class.text-bg-success]="gpsFix.accuracy <= 15"
+            [class.text-bg-warning]="gpsFix.accuracy > 15">
+            GPS ± {{ gpsFix.accuracy | number: '1.0-0' }} m
+        </span>
+        }
+
+        @if (loadingInProgress) {
+        <div class="chargement">
+            <div class="spinner-border text-primary" role="status">
+                <span class="visually-hidden">Chargement...</span>
+            </div>
+        </div>
+        }
+
+        <div class="toolbar p-2">
+            @if (mode === 'idle') {
+            @if (afficherChoixType) {
+            <div class="d-flex flex-column gap-2 mb-2">
+                @for (type of typesLigne; track type) {
+                <button type="button" class="btn btn-lg text-white" [style.background]="couleursLigne[type]"
+                    (click)="commencerLigne(type)">
+                    {{ libellesLigne[type] }}
+                </button>
+                }
+            </div>
+            }
+            <div class="d-flex gap-2 flex-wrap">
+                <button type="button" class="btn btn-primary btn-lg" (click)="afficherChoixType = !afficherChoixType">
+                    ➕ Ligne
+                </button>
+                <button type="button" class="btn btn-success btn-lg" (click)="commencerPoint('arbre')">
+                    🌳 Arbre
+                </button>
+                <button type="button" class="btn btn-secondary btn-lg" (click)="commencerPoint('entaille')">
+                    💧 Entaille
+                </button>
+            </div>
+            }
+            @else if (mode === 'ligne') {
+            <div class="d-flex gap-2 flex-wrap align-items-center mb-2">
+                <span class="badge fs-6 text-white" [style.background]="couleursLigne[typeLigneEnCours]">
+                    {{ libellesLigne[typeLigneEnCours] }} — {{ pointsEnCours.length }} point(s)
+                </span>
+                <input type="text" class="form-control form-control-lg nom-ligne" placeholder="Nom de la ligne (ex: M-01)"
+                    [(ngModel)]="nomLigneEnCours" name="nomLigne" />
+            </div>
+            <div class="d-flex gap-2 flex-wrap">
+                <button type="button" class="btn btn-primary btn-lg" (click)="ajouterPointGps()" [disabled]="!gpsFix"
+                    title="Ajouter un point à la position GPS actuelle">
+                    📍 Point GPS
+                </button>
+                <button type="button" class="btn btn-outline-secondary btn-lg" (click)="annulerDernierPoint()"
+                    [disabled]="pointsEnCours.length === 0">
+                    ↩ Retirer
+                </button>
+                <button type="button" class="btn btn-success btn-lg" (click)="enregistrerLigne()"
+                    [disabled]="pointsEnCours.length < 2 || enregistrementEnCours">
+                    💾 Enregistrer
+                </button>
+                <button type="button" class="btn btn-outline-danger btn-lg" (click)="annulerSaisie()">
+                    Annuler
+                </button>
+            </div>
+            <small class="text-muted d-block mt-1">Touchez la carte ou utilisez le GPS pour ajouter des points. Glissez un
+                point pour le déplacer.</small>
+            }
+            @else {
+            <div class="d-flex gap-2 flex-wrap align-items-center">
+                <span class="badge fs-6" [class.text-bg-success]="mode === 'arbre'"
+                    [class.text-bg-secondary]="mode === 'entaille'">
+                    {{ mode === 'arbre' ? '🌳 Nouvel arbre' : '💧 Nouvelle entaille' }}
+                </span>
+                <button type="button" class="btn btn-primary btn-lg" (click)="ajouterPointGps()" [disabled]="!gpsFix">
+                    📍 Position GPS
+                </button>
+                <button type="button" class="btn btn-outline-danger btn-lg" (click)="annulerSaisie()">
+                    Annuler
+                </button>
+            </div>
+            <small class="text-muted d-block mt-1">Touchez la carte à l'emplacement voulu ou utilisez votre position
+                GPS.</small>
+            }
+        </div>
+    </div>
+</div>
+
+@if (modal === 'arbre') {
+<emodal title="Nouvel arbre" [displayFooter]="false" (closeModal)="fermerModal()">
+    <div class="mb-3">
+        <label class="form-label" for="nomArbre">Nom / identifiant</label>
+        <input id="nomArbre" type="text" class="form-control" [(ngModel)]="formNom" name="nomArbre" maxlength="100" />
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="especeArbre">Espèce</label>
+        <input id="especeArbre" type="text" class="form-control" [(ngModel)]="formEspece" name="especeArbre"
+            maxlength="50" placeholder="Érable à sucre" />
+    </div>
+    <div class="mb-3 d-flex gap-2 align-items-end">
+        <div>
+            <label class="form-label" for="latArbre">Latitude</label>
+            <input id="latArbre" type="number" class="form-control" [(ngModel)]="formLat" name="latArbre" step="any" />
+        </div>
+        <div>
+            <label class="form-label" for="lngArbre">Longitude</label>
+            <input id="lngArbre" type="number" class="form-control" [(ngModel)]="formLng" name="lngArbre" step="any" />
+        </div>
+        <button type="button" class="btn btn-outline-primary" (click)="utiliserPositionGpsModal()" [disabled]="!gpsFix">
+            📍 Ma position
+        </button>
+    </div>
+    <div class="d-flex gap-2 justify-content-end">
+        <button type="button" class="btn btn-secondary" (click)="fermerModal()">Annuler</button>
+        <button type="button" class="btn btn-success" (click)="enregistrerArbre()"
+            [disabled]="enregistrementEnCours">Enregistrer</button>
+    </div>
+</emodal>
+}
+
+@if (modal === 'entaille') {
+<emodal title="Nouvelle entaille" [displayFooter]="false" (closeModal)="fermerModal()">
+    <div class="mb-3">
+        <label class="form-label" for="nomEntaille">Nom / identifiant</label>
+        <input id="nomEntaille" type="text" class="form-control" [(ngModel)]="formNom" name="nomEntaille"
+            maxlength="100" />
+    </div>
+    <div class="mb-3 d-flex gap-2 align-items-end">
+        <div>
+            <label class="form-label" for="latEntaille">Latitude</label>
+            <input id="latEntaille" type="number" class="form-control" [(ngModel)]="formLat" name="latEntaille"
+                step="any" />
+        </div>
+        <div>
+            <label class="form-label" for="lngEntaille">Longitude</label>
+            <input id="lngEntaille" type="number" class="form-control" [(ngModel)]="formLng" name="lngEntaille"
+                step="any" />
+        </div>
+        <button type="button" class="btn btn-outline-primary" (click)="utiliserPositionGpsModal()" [disabled]="!gpsFix">
+            📍 Ma position
+        </button>
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="arbreEntaille">Arbre (optionnel)</label>
+        <select id="arbreEntaille" class="form-select" [(ngModel)]="formIdArbre" name="arbreEntaille">
+            <option value="">Aucun</option>
+            @for (arbre of arbres; track arbre.id) {
+            <option [value]="arbre.id">{{ arbre.nom || arbre.id }}</option>
+            }
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="ligneEntaille">Ligne de tubelure (optionnel)</label>
+        <select id="ligneEntaille" class="form-select" [(ngModel)]="formIdLigne" name="ligneEntaille">
+            <option value="">Aucune</option>
+            @for (ligne of lignes; track ligne.id) {
+            <option [value]="ligne.id">{{ ligne.nom || libellesLigne[ligne.typeLigne ?? ''] || ligne.id }}</option>
+            }
+        </select>
+    </div>
+    <div class="d-flex gap-2 justify-content-end">
+        <button type="button" class="btn btn-secondary" (click)="fermerModal()">Annuler</button>
+        <button type="button" class="btn btn-success" (click)="enregistrerEntaille()"
+            [disabled]="enregistrementEnCours">Enregistrer</button>
+    </div>
+</emodal>
+}
+
+@if (modal === 'suppression') {
+<emodal title="Confirmer la suppression" [displayFooter]="false" (closeModal)="fermerModal()">
+    <p>Voulez-vous vraiment supprimer {{ libelleSuppression() }}</p>
+    <div class="d-flex gap-2 justify-content-end">
+        <button type="button" class="btn btn-secondary" (click)="fermerModal()">Annuler</button>
+        <button type="button" class="btn btn-danger" (click)="confirmerSuppression()"
+            [disabled]="enregistrementEnCours">Supprimer</button>
+    </div>
+</emodal>
+}

--- a/ErabliereIU/src/app/client-view/tubelure/tubelure.component.ts
+++ b/ErabliereIU/src/app/client-view/tubelure/tubelure.component.ts
@@ -1,0 +1,733 @@
+import { DecimalPipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ErabliereApi } from 'src/core/erabliereapi.service';
+import { EModalComponent } from 'src/generic/modal/emodal.component';
+import { LigneTubelure, TYPES_LIGNE } from 'src/model/ligneTubelure';
+import { Arbre } from 'src/model/arbre';
+import { Entaille } from 'src/model/entaille';
+
+type ModeTubelure = 'idle' | 'ligne' | 'arbre' | 'entaille';
+
+const COULEURS_LIGNE: Record<string, string> = {
+    principale: '#d62728',
+    secondaire: '#ff7f0e',
+    laterale: '#1f77b4'
+};
+
+const LIBELLES_LIGNE: Record<string, string> = {
+    principale: 'Ligne principale',
+    secondaire: 'Ligne secondaire',
+    laterale: 'Ligne latérale'
+};
+
+@Component({
+    selector: 'app-tubelure',
+    templateUrl: './tubelure.component.html',
+    styleUrls: ['./tubelure.component.css'],
+    imports: [
+        DecimalPipe,
+        FormsModule,
+        EModalComponent
+    ],
+    changeDetection: ChangeDetectionStrategy.Eager
+})
+export class TubelureComponent implements OnInit, OnChanges, OnDestroy {
+
+    @Input() idErabliereSelectionee?: any;
+
+    constructor(private readonly _api: ErabliereApi) { }
+
+    map?: mapboxgl.Map;
+    private _mapboxgl?: any;
+    private _mapChargee = false;
+    private _geoJsonReseau: any = { type: 'FeatureCollection', features: [] };
+    private _popup?: any;
+
+    typesLigne = TYPES_LIGNE;
+    couleursLigne = COULEURS_LIGNE;
+    libellesLigne = LIBELLES_LIGNE;
+
+    loadingInProgress = true;
+    error?: string;
+
+    // Machine à états de saisie
+    mode: ModeTubelure = 'idle';
+    afficherChoixType = false;
+    typeLigneEnCours: string = 'laterale';
+    nomLigneEnCours: string = '';
+    pointsEnCours: [number, number][] = [];
+    ligneEnEditionId?: string;
+    enregistrementEnCours = false;
+
+    // GPS
+    gpsFix?: { lng: number, lat: number, accuracy: number };
+    erreurGps?: string;
+
+    // Modales
+    modal: 'arbre' | 'entaille' | 'suppression' | null = null;
+    formNom: string = '';
+    formEspece: string = '';
+    formLng?: number;
+    formLat?: number;
+    formIdArbre: string = '';
+    formIdLigne: string = '';
+    arbres: Arbre[] = [];
+    lignes: LigneTubelure[] = [];
+    featureASupprimer?: { type: string, id: string, nom?: string };
+
+    ngOnInit(): void {
+        this.initMap();
+    }
+
+    ngOnChanges(changes: SimpleChanges): void {
+        if (changes.idErabliereSelectionee && !changes.idErabliereSelectionee.firstChange) {
+            this.annulerSaisie();
+            this.chargerReseau(true);
+        }
+    }
+
+    ngOnDestroy(): void {
+        this.map?.remove();
+    }
+
+    async initMap() {
+        try {
+            const accessToken = await this._api.getMapAccessToken('mapbox');
+
+            const mapboxgl = (await import('mapbox-gl')).default;
+            this._mapboxgl = mapboxgl;
+
+            this.map = new mapboxgl.Map({
+                accessToken: accessToken.accessToken,
+                container: 'map-tubelure',
+                style: 'mapbox://styles/mapbox/outdoors-v12',
+                zoom: 15,
+                center: [-71.254028, 46.829853]
+            });
+
+            const geolocate = new mapboxgl.GeolocateControl({
+                positionOptions: { enableHighAccuracy: true },
+                trackUserLocation: true,
+                showUserHeading: true,
+                showAccuracyCircle: true
+            });
+
+            this.map.addControl(new mapboxgl.NavigationControl(), 'top-right');
+            this.map.addControl(geolocate, 'top-right');
+
+            geolocate.on('geolocate', (e: any) => {
+                this.gpsFix = {
+                    lng: e.coords.longitude,
+                    lat: e.coords.latitude,
+                    accuracy: e.coords.accuracy
+                };
+                this.erreurGps = undefined;
+            });
+
+            geolocate.on('error', (e: any) => {
+                if (e?.code === 1) {
+                    this.erreurGps = "Accès à la position refusé. Autorisez la géolocalisation dans votre navigateur pour utiliser le bouton GPS.";
+                }
+                else {
+                    this.erreurGps = "Position GPS indisponible. Vous pouvez quand même placer des points en touchant la carte.";
+                }
+            });
+
+            this.map.on('load', () => {
+                if (this.map == null) {
+                    return;
+                }
+
+                this.map.addSource('tubelure', {
+                    type: 'geojson',
+                    data: this._geoJsonReseau
+                });
+
+                this.map.addSource('edition', {
+                    type: 'geojson',
+                    data: { type: 'FeatureCollection', features: [] }
+                });
+
+                this.map.addLayer({
+                    id: 'lignes',
+                    type: 'line',
+                    source: 'tubelure',
+                    filter: ['==', ['get', 'feature'], 'ligne'],
+                    layout: { 'line-cap': 'round', 'line-join': 'round' },
+                    paint: {
+                        'line-color': ['match', ['get', 'typeLigne'],
+                            'principale', COULEURS_LIGNE['principale'],
+                            'secondaire', COULEURS_LIGNE['secondaire'],
+                            'laterale', COULEURS_LIGNE['laterale'],
+                            '#888888'],
+                        'line-width': ['match', ['get', 'typeLigne'],
+                            'principale', 6,
+                            'secondaire', 4,
+                            3]
+                    }
+                });
+
+                this.map.addLayer({
+                    id: 'arbres',
+                    type: 'circle',
+                    source: 'tubelure',
+                    filter: ['==', ['get', 'feature'], 'arbre'],
+                    paint: {
+                        'circle-radius': 8,
+                        'circle-color': '#2ca02c',
+                        'circle-stroke-width': 2,
+                        'circle-stroke-color': '#ffffff'
+                    }
+                });
+
+                this.map.addLayer({
+                    id: 'entailles',
+                    type: 'circle',
+                    source: 'tubelure',
+                    filter: ['==', ['get', 'feature'], 'entaille'],
+                    paint: {
+                        'circle-radius': 6,
+                        'circle-color': '#8c564b',
+                        'circle-stroke-width': 2,
+                        'circle-stroke-color': '#ffffff'
+                    }
+                });
+
+                this.map.addLayer({
+                    id: 'edition-ligne',
+                    type: 'line',
+                    source: 'edition',
+                    filter: ['==', ['geometry-type'], 'LineString'],
+                    layout: { 'line-cap': 'round', 'line-join': 'round' },
+                    paint: {
+                        'line-color': ['get', 'couleur'],
+                        'line-width': 4,
+                        'line-dasharray': [2, 1.5]
+                    }
+                });
+
+                this.map.addLayer({
+                    id: 'edition-points',
+                    type: 'circle',
+                    source: 'edition',
+                    filter: ['==', ['geometry-type'], 'Point'],
+                    paint: {
+                        'circle-radius': 10,
+                        'circle-color': ['get', 'couleur'],
+                        'circle-stroke-width': 2,
+                        'circle-stroke-color': '#ffffff'
+                    }
+                });
+
+                this.map.on('click', (e) => this.clicCarte(e));
+
+                this.map.on('mousedown', 'edition-points', (e) => this.demarrerDragSommet(e));
+                this.map.on('touchstart', 'edition-points', (e) => this.demarrerDragSommet(e));
+
+                for (const layer of ['lignes', 'arbres', 'entailles']) {
+                    this.map.on('mouseenter', layer, () => {
+                        if (this.map != null && this.mode === 'idle') {
+                            this.map.getCanvas().style.cursor = 'pointer';
+                        }
+                    });
+                    this.map.on('mouseleave', layer, () => {
+                        if (this.map != null) {
+                            this.map.getCanvas().style.cursor = '';
+                        }
+                    });
+                }
+
+                this._mapChargee = true;
+                this.chargerReseau(true);
+                geolocate.trigger();
+            });
+        }
+        catch (e) {
+            console.error('Erreur lors de l\'initialisation de la carte', e);
+            this.error = 'Erreur lors de l\'initialisation de la carte.';
+            this.loadingInProgress = false;
+        }
+    }
+
+    async chargerReseau(recentrer: boolean = false) {
+        if (this.idErabliereSelectionee == null) {
+            return;
+        }
+
+        this.loadingInProgress = true;
+
+        try {
+            this._geoJsonReseau = await this._api.getTubelureGeoJson(this.idErabliereSelectionee);
+            this.error = undefined;
+        }
+        catch (e) {
+            console.error('Erreur lors de la récupération du réseau de tubelure', e);
+            this.error = 'Erreur lors de la récupération du réseau de tubelure.';
+            this.loadingInProgress = false;
+            return;
+        }
+
+        this.majSourceReseau();
+
+        if (recentrer) {
+            await this.recentrerCarte();
+        }
+
+        this.loadingInProgress = false;
+    }
+
+    private majSourceReseau() {
+        if (!this._mapChargee || this.map == null) {
+            return;
+        }
+
+        // La ligne en cours de modification est masquée du réseau affiché
+        const data = this.ligneEnEditionId == null
+            ? this._geoJsonReseau
+            : {
+                type: 'FeatureCollection',
+                features: this._geoJsonReseau.features.filter((f: any) => f.properties?.id !== this.ligneEnEditionId)
+            };
+
+        (this.map.getSource('tubelure') as mapboxgl.GeoJSONSource)?.setData(data);
+    }
+
+    private async recentrerCarte() {
+        if (this.map == null || this._mapboxgl == null) {
+            return;
+        }
+
+        const bounds = new this._mapboxgl.LngLatBounds();
+        let nbCoords = 0;
+
+        for (const feature of this._geoJsonReseau.features ?? []) {
+            if (feature.geometry.type === 'Point') {
+                bounds.extend(feature.geometry.coordinates);
+                nbCoords++;
+            }
+            else if (feature.geometry.type === 'LineString') {
+                for (const coord of feature.geometry.coordinates) {
+                    bounds.extend(coord);
+                    nbCoords++;
+                }
+            }
+        }
+
+        if (nbCoords > 0) {
+            this.map.fitBounds(bounds, { padding: 80, maxZoom: 17 });
+            return;
+        }
+
+        try {
+            const erabliere = await this._api.getErabliere(this.idErabliereSelectionee, true, true);
+
+            if (erabliere?.latitude && erabliere?.longitude) {
+                this.map.setCenter([erabliere.longitude, erabliere.latitude]);
+                this.map.setZoom(15);
+            }
+        }
+        catch (e) {
+            console.error('Erreur lors de la récupération de l\'érablière pour centrer la carte', e);
+        }
+    }
+
+    // ---- Interactions carte ----
+
+    private clicCarte(e: any) {
+        if (this.map == null) {
+            return;
+        }
+
+        if (this.mode === 'ligne') {
+            // Un tap sur un sommet existant ne doit pas ajouter de point (c'est un drag raté)
+            const sommets = this.map.queryRenderedFeatures(e.point, { layers: ['edition-points'] });
+            if (sommets.length > 0) {
+                return;
+            }
+
+            this.ajouterPoint([e.lngLat.lng, e.lngLat.lat]);
+        }
+        else if (this.mode === 'arbre' || this.mode === 'entaille') {
+            this.ouvrirModalPoint(e.lngLat.lng, e.lngLat.lat);
+        }
+        else {
+            const features = this.map.queryRenderedFeatures(e.point, { layers: ['entailles', 'arbres', 'lignes'] });
+            if (features.length > 0) {
+                this.ouvrirPopupFeature(features[0], e.lngLat);
+            }
+        }
+    }
+
+    private ouvrirPopupFeature(feature: any, lngLat: any) {
+        if (this.map == null || this._mapboxgl == null) {
+            return;
+        }
+
+        const props = feature.properties ?? {};
+        const type = props.feature;
+
+        const div = document.createElement('div');
+
+        const titre = document.createElement('h6');
+        if (type === 'ligne') {
+            titre.textContent = `${LIBELLES_LIGNE[props.typeLigne] ?? 'Ligne'}${props.nom ? ' « ' + props.nom + ' »' : ''}`;
+        }
+        else if (type === 'arbre') {
+            titre.textContent = `Arbre${props.nom ? ' « ' + props.nom + ' »' : ''}${props.espece ? ' (' + props.espece + ')' : ''}`;
+        }
+        else {
+            titre.textContent = `Entaille${props.nom ? ' « ' + props.nom + ' »' : ''}`;
+        }
+        div.appendChild(titre);
+
+        const boutons = document.createElement('div');
+        boutons.className = 'd-flex gap-2';
+
+        if (type === 'ligne') {
+            const btnModifier = document.createElement('button');
+            btnModifier.className = 'btn btn-sm btn-outline-primary';
+            btnModifier.textContent = 'Modifier';
+            btnModifier.addEventListener('click', () => {
+                this.fermerPopup();
+                this.modifierLigne(feature);
+            });
+            boutons.appendChild(btnModifier);
+        }
+
+        const btnSupprimer = document.createElement('button');
+        btnSupprimer.className = 'btn btn-sm btn-outline-danger';
+        btnSupprimer.textContent = 'Supprimer';
+        btnSupprimer.addEventListener('click', () => {
+            this.fermerPopup();
+            this.featureASupprimer = { type: type, id: props.id, nom: props.nom };
+            this.modal = 'suppression';
+        });
+        boutons.appendChild(btnSupprimer);
+
+        div.appendChild(boutons);
+
+        this._popup = new this._mapboxgl.Popup()
+            .setLngLat(lngLat)
+            .setDOMContent(div)
+            .addTo(this.map);
+    }
+
+    private fermerPopup() {
+        this._popup?.remove();
+        this._popup = undefined;
+    }
+
+    private demarrerDragSommet(e: any) {
+        if (this.map == null || this.mode !== 'ligne' || e.features == null || e.features.length === 0) {
+            return;
+        }
+
+        e.preventDefault();
+
+        const index = e.features[0].properties.index;
+        const map = this.map;
+
+        const onMove = (ev: any) => {
+            this.pointsEnCours[index] = [ev.lngLat.lng, ev.lngLat.lat];
+            this.majSourceEdition();
+        };
+
+        const onUp = () => {
+            map.off('mousemove', onMove);
+            map.off('touchmove', onMove);
+            map.dragPan.enable();
+        };
+
+        map.dragPan.disable();
+        map.on('mousemove', onMove);
+        map.on('touchmove', onMove);
+        map.once('mouseup', onUp);
+        map.once('touchend', onUp);
+    }
+
+    private majSourceEdition() {
+        if (!this._mapChargee || this.map == null) {
+            return;
+        }
+
+        const couleur = COULEURS_LIGNE[this.typeLigneEnCours] ?? '#888888';
+        const features: any[] = [];
+
+        if (this.pointsEnCours.length >= 2) {
+            features.push({
+                type: 'Feature',
+                geometry: { type: 'LineString', coordinates: this.pointsEnCours },
+                properties: { couleur: couleur }
+            });
+        }
+
+        this.pointsEnCours.forEach((point, index) => {
+            features.push({
+                type: 'Feature',
+                geometry: { type: 'Point', coordinates: point },
+                properties: { couleur: couleur, index: index }
+            });
+        });
+
+        (this.map.getSource('edition') as mapboxgl.GeoJSONSource)?.setData({
+            type: 'FeatureCollection',
+            features: features
+        } as any);
+    }
+
+    // ---- Saisie d'une ligne ----
+
+    commencerLigne(type: string) {
+        this.fermerPopup();
+        this.afficherChoixType = false;
+        this.typeLigneEnCours = type;
+        this.nomLigneEnCours = '';
+        this.pointsEnCours = [];
+        this.ligneEnEditionId = undefined;
+        this.mode = 'ligne';
+        this.majSourceEdition();
+    }
+
+    modifierLigne(feature: any) {
+        this.typeLigneEnCours = feature.properties?.typeLigne ?? 'laterale';
+        this.nomLigneEnCours = feature.properties?.nom ?? '';
+        this.ligneEnEditionId = feature.properties?.id;
+
+        // La géométrie retournée par queryRenderedFeatures peut être tronquée aux tuiles
+        // visibles : on relit la ligne complète depuis le GeoJson chargé.
+        const ligneComplete = this._geoJsonReseau.features
+            .find((f: any) => f.properties?.id === this.ligneEnEditionId);
+        this.pointsEnCours = (ligneComplete ?? feature).geometry.coordinates
+            .map((c: number[]) => [c[0], c[1]] as [number, number]);
+
+        this.mode = 'ligne';
+        this.majSourceReseau();
+        this.majSourceEdition();
+    }
+
+    ajouterPointGps() {
+        if (this.gpsFix == null) {
+            return;
+        }
+
+        if (this.mode === 'ligne') {
+            this.ajouterPoint([this.gpsFix.lng, this.gpsFix.lat]);
+        }
+        else if (this.mode === 'arbre' || this.mode === 'entaille') {
+            this.ouvrirModalPoint(this.gpsFix.lng, this.gpsFix.lat);
+        }
+    }
+
+    private ajouterPoint(point: [number, number]) {
+        this.pointsEnCours.push(point);
+        this.majSourceEdition();
+    }
+
+    annulerDernierPoint() {
+        this.pointsEnCours.pop();
+        this.majSourceEdition();
+    }
+
+    async enregistrerLigne() {
+        if (this.idErabliereSelectionee == null || this.pointsEnCours.length < 2) {
+            return;
+        }
+
+        this.enregistrementEnCours = true;
+
+        const ligne: LigneTubelure = {
+            id: this.ligneEnEditionId,
+            idErabliere: this.idErabliereSelectionee,
+            nom: this.nomLigneEnCours || undefined,
+            typeLigne: this.typeLigneEnCours,
+            coordonneesJson: JSON.stringify(this.pointsEnCours)
+        };
+
+        try {
+            if (this.ligneEnEditionId != null) {
+                await this._api.putLigneTubelure(this.idErabliereSelectionee, ligne);
+            }
+            else {
+                await this._api.postLigneTubelure(this.idErabliereSelectionee, ligne);
+            }
+
+            this.error = undefined;
+            this.annulerSaisie();
+            await this.chargerReseau();
+        }
+        catch (e) {
+            console.error('Erreur lors de l\'enregistrement de la ligne', e);
+            this.error = 'Erreur lors de l\'enregistrement de la ligne.';
+        }
+
+        this.enregistrementEnCours = false;
+    }
+
+    annulerSaisie() {
+        this.mode = 'idle';
+        this.afficherChoixType = false;
+        this.pointsEnCours = [];
+        this.nomLigneEnCours = '';
+        this.ligneEnEditionId = undefined;
+        this.majSourceEdition();
+        this.majSourceReseau();
+    }
+
+    // ---- Saisie d'un arbre ou d'une entaille ----
+
+    commencerPoint(mode: 'arbre' | 'entaille') {
+        this.fermerPopup();
+        this.afficherChoixType = false;
+        this.mode = mode;
+    }
+
+    async ouvrirModalPoint(lng: number, lat: number) {
+        this.formNom = '';
+        this.formEspece = '';
+        this.formLng = lng;
+        this.formLat = lat;
+        this.formIdArbre = '';
+        this.formIdLigne = '';
+
+        if (this.mode === 'entaille') {
+            try {
+                [this.arbres, this.lignes] = await Promise.all([
+                    this._api.getArbres(this.idErabliereSelectionee),
+                    this._api.getLignesTubelure(this.idErabliereSelectionee)
+                ]);
+            }
+            catch (e) {
+                console.error('Erreur lors de la récupération des arbres et des lignes', e);
+                this.arbres = [];
+                this.lignes = [];
+            }
+        }
+
+        this.modal = this.mode === 'arbre' ? 'arbre' : 'entaille';
+    }
+
+    utiliserPositionGpsModal() {
+        if (this.gpsFix != null) {
+            this.formLng = this.gpsFix.lng;
+            this.formLat = this.gpsFix.lat;
+        }
+    }
+
+    async enregistrerArbre() {
+        if (this.idErabliereSelectionee == null || this.formLng == null || this.formLat == null) {
+            return;
+        }
+
+        this.enregistrementEnCours = true;
+
+        const arbre: Arbre = {
+            idErabliere: this.idErabliereSelectionee,
+            nom: this.formNom || undefined,
+            espece: this.formEspece || undefined,
+            longitude: this.formLng,
+            latitude: this.formLat
+        };
+
+        try {
+            await this._api.postArbre(this.idErabliereSelectionee, arbre);
+            this.error = undefined;
+            this.fermerModal();
+            this.mode = 'idle';
+            await this.chargerReseau();
+        }
+        catch (e) {
+            console.error('Erreur lors de l\'enregistrement de l\'arbre', e);
+            this.error = 'Erreur lors de l\'enregistrement de l\'arbre.';
+        }
+
+        this.enregistrementEnCours = false;
+    }
+
+    async enregistrerEntaille() {
+        if (this.idErabliereSelectionee == null || this.formLng == null || this.formLat == null) {
+            return;
+        }
+
+        this.enregistrementEnCours = true;
+
+        const entaille: Entaille = {
+            idErabliere: this.idErabliereSelectionee,
+            nom: this.formNom || undefined,
+            longitude: this.formLng,
+            latitude: this.formLat,
+            idArbre: this.formIdArbre || null,
+            idLigneTubelure: this.formIdLigne || null
+        };
+
+        try {
+            await this._api.postEntaille(this.idErabliereSelectionee, entaille);
+            this.error = undefined;
+            this.fermerModal();
+            this.mode = 'idle';
+            await this.chargerReseau();
+        }
+        catch (e) {
+            console.error('Erreur lors de l\'enregistrement de l\'entaille', e);
+            this.error = 'Erreur lors de l\'enregistrement de l\'entaille.';
+        }
+
+        this.enregistrementEnCours = false;
+    }
+
+    // ---- Suppression ----
+
+    async confirmerSuppression() {
+        if (this.idErabliereSelectionee == null || this.featureASupprimer == null) {
+            return;
+        }
+
+        this.enregistrementEnCours = true;
+
+        try {
+            const { type, id } = this.featureASupprimer;
+
+            if (type === 'ligne') {
+                await this._api.deleteLigneTubelure(this.idErabliereSelectionee, id);
+            }
+            else if (type === 'arbre') {
+                await this._api.deleteArbre(this.idErabliereSelectionee, id);
+            }
+            else {
+                await this._api.deleteEntaille(this.idErabliereSelectionee, id);
+            }
+
+            this.error = undefined;
+            this.fermerModal();
+            await this.chargerReseau();
+        }
+        catch (e) {
+            console.error('Erreur lors de la suppression', e);
+            this.error = 'Erreur lors de la suppression.';
+        }
+
+        this.enregistrementEnCours = false;
+    }
+
+    libelleSuppression(): string {
+        if (this.featureASupprimer == null) {
+            return '';
+        }
+
+        const nom = this.featureASupprimer.nom ? ` « ${this.featureASupprimer.nom} »` : '';
+
+        switch (this.featureASupprimer.type) {
+            case 'ligne':
+                return `la ligne${nom} et son tracé ? Les entailles raccordées seront conservées`;
+            case 'arbre':
+                return `l'arbre${nom} ? Ses entailles seront conservées`;
+            default:
+                return `l'entaille${nom} ?`;
+        }
+    }
+
+    fermerModal() {
+        this.modal = null;
+        this.featureASupprimer = undefined;
+    }
+}

--- a/ErabliereIU/src/core/erabliereapi.service.ts
+++ b/ErabliereIU/src/core/erabliereapi.service.ts
@@ -35,6 +35,9 @@ import { Appareil } from 'src/model/appareil';
 import { IpInfo } from 'src/model/ipinfo';
 import { WeatherProviderResponse } from 'src/model/weatherProviderResponse';
 import { ChirpstackSrvConfig } from 'src/model/chripstacksrvconfig';
+import { LigneTubelure } from 'src/model/ligneTubelure';
+import { Arbre } from 'src/model/arbre';
+import { Entaille } from 'src/model/entaille';
 
 @Injectable({ providedIn: 'root' })
 export class ErabliereApi {
@@ -700,6 +703,74 @@ export class ErabliereApi {
         }
 
         return await firstValueFrom(this._httpClient.get<any>(url, { headers: header }));
+    }
+
+    async getTubelureGeoJson(idErabliereSelectionnee: any): Promise<any> {
+        const headers = await this.getHeaders();
+        return await firstValueFrom(this._httpClient.get<any>(this._environmentService.apiUrl + '/erablieres/' + idErabliereSelectionnee + '/Tubelure/GeoJson', { headers: headers }));
+    }
+
+    async getLignesTubelure(idErabliereSelectionnee: any): Promise<LigneTubelure[]> {
+        const headers = await this.getHeaders();
+        const rtn = firstValueFrom(this._httpClient.get<LigneTubelure[]>(this._environmentService.apiUrl + '/erablieres/' + idErabliereSelectionnee + '/LignesTubelure?$orderby=Nom', { headers: headers }));
+        return rtn ?? [];
+    }
+
+    async postLigneTubelure(idErabliereSelectionnee: any, ligne: LigneTubelure): Promise<any> {
+        const headers = await this.getHeaders();
+        return firstValueFrom(this._httpClient.post<any>(this._environmentService.apiUrl + '/erablieres/' + idErabliereSelectionnee + '/LignesTubelure', ligne, { headers: headers }));
+    }
+
+    async putLigneTubelure(idErabliereSelectionnee: any, ligne: LigneTubelure): Promise<any> {
+        const headers = await this.getHeaders();
+        return firstValueFrom(this._httpClient.put<any>(this._environmentService.apiUrl + '/erablieres/' + idErabliereSelectionnee + '/LignesTubelure', ligne, { headers: headers }));
+    }
+
+    async deleteLigneTubelure(idErabliereSelectionnee: any, idLigne: any): Promise<any> {
+        const headers = await this.getHeaders();
+        return firstValueFrom(this._httpClient.delete(this._environmentService.apiUrl + '/erablieres/' + idErabliereSelectionnee + '/LignesTubelure/' + idLigne, { headers: headers }));
+    }
+
+    async getArbres(idErabliereSelectionnee: any): Promise<Arbre[]> {
+        const headers = await this.getHeaders();
+        const rtn = firstValueFrom(this._httpClient.get<Arbre[]>(this._environmentService.apiUrl + '/erablieres/' + idErabliereSelectionnee + '/Arbres?$orderby=Nom', { headers: headers }));
+        return rtn ?? [];
+    }
+
+    async postArbre(idErabliereSelectionnee: any, arbre: Arbre): Promise<any> {
+        const headers = await this.getHeaders();
+        return firstValueFrom(this._httpClient.post<any>(this._environmentService.apiUrl + '/erablieres/' + idErabliereSelectionnee + '/Arbres', arbre, { headers: headers }));
+    }
+
+    async putArbre(idErabliereSelectionnee: any, arbre: Arbre): Promise<any> {
+        const headers = await this.getHeaders();
+        return firstValueFrom(this._httpClient.put<any>(this._environmentService.apiUrl + '/erablieres/' + idErabliereSelectionnee + '/Arbres', arbre, { headers: headers }));
+    }
+
+    async deleteArbre(idErabliereSelectionnee: any, idArbre: any): Promise<any> {
+        const headers = await this.getHeaders();
+        return firstValueFrom(this._httpClient.delete(this._environmentService.apiUrl + '/erablieres/' + idErabliereSelectionnee + '/Arbres/' + idArbre, { headers: headers }));
+    }
+
+    async getEntailles(idErabliereSelectionnee: any): Promise<Entaille[]> {
+        const headers = await this.getHeaders();
+        const rtn = firstValueFrom(this._httpClient.get<Entaille[]>(this._environmentService.apiUrl + '/erablieres/' + idErabliereSelectionnee + '/Entailles?$orderby=Nom', { headers: headers }));
+        return rtn ?? [];
+    }
+
+    async postEntaille(idErabliereSelectionnee: any, entaille: Entaille): Promise<any> {
+        const headers = await this.getHeaders();
+        return firstValueFrom(this._httpClient.post<any>(this._environmentService.apiUrl + '/erablieres/' + idErabliereSelectionnee + '/Entailles', entaille, { headers: headers }));
+    }
+
+    async putEntaille(idErabliereSelectionnee: any, entaille: Entaille): Promise<any> {
+        const headers = await this.getHeaders();
+        return firstValueFrom(this._httpClient.put<any>(this._environmentService.apiUrl + '/erablieres/' + idErabliereSelectionnee + '/Entailles', entaille, { headers: headers }));
+    }
+
+    async deleteEntaille(idErabliereSelectionnee: any, idEntaille: any): Promise<any> {
+        const headers = await this.getHeaders();
+        return firstValueFrom(this._httpClient.delete(this._environmentService.apiUrl + '/erablieres/' + idErabliereSelectionnee + '/Entailles/' + idEntaille, { headers: headers }));
     }
 
     async getApiKeys(): Promise<ApiKey[]> {

--- a/ErabliereIU/src/model/arbre.ts
+++ b/ErabliereIU/src/model/arbre.ts
@@ -1,0 +1,10 @@
+export class Arbre {
+    id?: string
+    idErabliere?: string
+    nom?: string
+    espece?: string
+    latitude: number = 0
+    longitude: number = 0
+    dc?: string
+    dm?: string
+}

--- a/ErabliereIU/src/model/entaille.ts
+++ b/ErabliereIU/src/model/entaille.ts
@@ -1,0 +1,11 @@
+export class Entaille {
+    id?: string
+    idErabliere?: string
+    nom?: string
+    latitude: number = 0
+    longitude: number = 0
+    idArbre?: string | null
+    idLigneTubelure?: string | null
+    dc?: string
+    dm?: string
+}

--- a/ErabliereIU/src/model/ligneTubelure.ts
+++ b/ErabliereIU/src/model/ligneTubelure.ts
@@ -1,0 +1,13 @@
+export const TYPES_LIGNE = ['principale', 'secondaire', 'laterale'] as const;
+
+export type TypeLigne = typeof TYPES_LIGNE[number];
+
+export class LigneTubelure {
+    id?: string
+    idErabliere?: string
+    nom?: string
+    typeLigne?: string
+    coordonneesJson?: string
+    dc?: string
+    dm?: string
+}

--- a/ErabliereModel/Action/Post/PostAlerteCapteur.cs
+++ b/ErabliereModel/Action/Post/PostAlerteCapteur.cs
@@ -1,0 +1,62 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ErabliereApi.Donnees.Action.Post;
+
+/// <summary>
+/// Modèle de création d'une alerte de capteur. Ne contient volontairement aucune propriété de
+/// navigation afin d'empêcher l'over-posting vers des entités liées.
+/// </summary>
+public class PostAlerteCapteur
+{
+    /// <summary>
+    /// L'id guid si le client désire initialiser l'id
+    /// </summary>
+    public Guid? Id { get; set; }
+
+    /// <summary>
+    /// L'id du capteur
+    /// </summary>
+    [Required]
+    public Guid? IdCapteur { get; set; }
+
+    /// <summary>
+    /// Le nom de l'alerte
+    /// </summary>
+    [MaxLength(100)]
+    public string? Nom { get; set; }
+
+    /// <summary>
+    /// Une liste d'adresse email séparer par des ';'
+    /// </summary>
+    /// <example>exemple@courriel.com;exemple2@courriel.com</example>
+    [MaxLength(200)]
+    public string? EnvoyerA { get; set; }
+
+    /// <summary>
+    /// Une liste de numéros de téléphone séparés par des ';'
+    /// </summary>
+    /// <example>+14375327599;+15749375019</example>
+    [MaxLength(200)]
+    public string? TexterA { get; set; }
+
+    /// <summary>
+    /// Date de création
+    /// </summary>
+    public DateTime? DC { get; set; }
+
+    /// <summary>
+    /// La valeur minimal de ce capteur
+    /// </summary>
+    public decimal? MinValue { get; set; }
+
+    /// <summary>
+    /// La valeur maximal de ce capteur
+    /// </summary>
+    public decimal? MaxValue { get; set; }
+
+    /// <summary>
+    /// Indique si l'alerte est activé
+    /// </summary>
+    public bool IsEnable { get; set; }
+}

--- a/ErabliereModel/Action/Post/PostArbre.cs
+++ b/ErabliereModel/Action/Post/PostArbre.cs
@@ -1,0 +1,43 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ErabliereApi.Donnees.Action.Post;
+
+/// <summary>
+/// Modèle de création d'un arbre cartographié. Ne contient volontairement aucune
+/// propriété de navigation afin d'empêcher l'over-posting vers des entités liées.
+/// </summary>
+public class PostArbre
+{
+    /// <summary>
+    /// L'id guid si le client désire initialiser l'id
+    /// </summary>
+    public Guid? Id { get; set; }
+
+    /// <summary>
+    /// La clé étrangère de l'érablière
+    /// </summary>
+    public Guid? IdErabliere { get; set; }
+
+    /// <summary>
+    /// L'identifiant ou le nom de l'arbre
+    /// </summary>
+    [MaxLength(100, ErrorMessage = "Le nom de l'arbre ne peut pas dépasser 100 caractères.")]
+    public string? Nom { get; set; }
+
+    /// <summary>
+    /// L'espèce de l'arbre
+    /// </summary>
+    [MaxLength(50, ErrorMessage = "L'espèce de l'arbre ne peut pas dépasser 50 caractères.")]
+    public string? Espece { get; set; }
+
+    /// <summary>
+    /// La latitude de l'arbre
+    /// </summary>
+    public double Latitude { get; set; }
+
+    /// <summary>
+    /// La longitude de l'arbre
+    /// </summary>
+    public double Longitude { get; set; }
+}

--- a/ErabliereModel/Action/Post/PostBaril.cs
+++ b/ErabliereModel/Action/Post/PostBaril.cs
@@ -1,0 +1,38 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ErabliereApi.Donnees.Action.Post;
+
+/// <summary>
+/// Modèle de création d'un baril. Ne contient volontairement aucune propriété de navigation
+/// afin d'empêcher l'over-posting vers des entités liées.
+/// </summary>
+public class PostBaril
+{
+    /// <summary>
+    /// L'id guid si le client désire initialiser l'id
+    /// </summary>
+    public Guid? Id { get; set; }
+
+    /// <summary>
+    /// La clé étrangère de l'érablière possédant le baril
+    /// </summary>
+    public Guid? IdErabliere { get; set; }
+
+    /// <summary>
+    /// Date où le baril a été fermé
+    /// </summary>
+    public DateTimeOffset? DF { get; set; }
+
+    /// <summary>
+    /// Estimation de la qualité du sirop
+    /// </summary>
+    [MaxLength(15)]
+    public string? QE { get; set; }
+
+    /// <summary>
+    /// Qualité du sirop après classement
+    /// </summary>
+    [MaxLength(15)]
+    public string? Q { get; set; }
+}

--- a/ErabliereModel/Action/Post/PostDompeux.cs
+++ b/ErabliereModel/Action/Post/PostDompeux.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace ErabliereApi.Donnees.Action.Post;
+
+/// <summary>
+/// Modèle de création d'un dompeux. Ne contient volontairement aucune propriété de navigation
+/// afin d'empêcher l'over-posting vers des entités liées.
+/// </summary>
+public class PostDompeux
+{
+    /// <summary>
+    /// L'id guid si le client désire initialiser l'id
+    /// </summary>
+    public Guid? Id { get; set; }
+
+    /// <summary>
+    /// La clé étrangère de l'érablière
+    /// </summary>
+    public Guid? IdErabliere { get; set; }
+
+    /// <summary>
+    /// Date de l'occurence
+    /// </summary>
+    public DateTimeOffset? T { get; set; }
+
+    /// <summary>
+    /// La date de début
+    /// </summary>
+    public DateTimeOffset? DD { get; set; }
+
+    /// <summary>
+    /// La date de fin
+    /// </summary>
+    public DateTimeOffset? DF { get; set; }
+}

--- a/ErabliereModel/Action/Post/PostEntaille.cs
+++ b/ErabliereModel/Action/Post/PostEntaille.cs
@@ -1,0 +1,47 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ErabliereApi.Donnees.Action.Post;
+
+/// <summary>
+/// Modèle de création d'une entaille cartographiée. Ne contient volontairement aucune
+/// propriété de navigation afin d'empêcher l'over-posting vers des entités liées.
+/// </summary>
+public class PostEntaille
+{
+    /// <summary>
+    /// L'id guid si le client désire initialiser l'id
+    /// </summary>
+    public Guid? Id { get; set; }
+
+    /// <summary>
+    /// La clé étrangère de l'érablière
+    /// </summary>
+    public Guid? IdErabliere { get; set; }
+
+    /// <summary>
+    /// L'identifiant ou le nom de l'entaille
+    /// </summary>
+    [MaxLength(100, ErrorMessage = "Le nom de l'entaille ne peut pas dépasser 100 caractères.")]
+    public string? Nom { get; set; }
+
+    /// <summary>
+    /// La latitude de l'entaille
+    /// </summary>
+    public double Latitude { get; set; }
+
+    /// <summary>
+    /// La longitude de l'entaille
+    /// </summary>
+    public double Longitude { get; set; }
+
+    /// <summary>
+    /// La clé étrangère optionnelle de l'arbre entaillé
+    /// </summary>
+    public Guid? IdArbre { get; set; }
+
+    /// <summary>
+    /// La clé étrangère optionnelle de la ligne de tubelure raccordée
+    /// </summary>
+    public Guid? IdLigneTubelure { get; set; }
+}

--- a/ErabliereModel/Action/Post/PostLigneTubelure.cs
+++ b/ErabliereModel/Action/Post/PostLigneTubelure.cs
@@ -1,0 +1,39 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ErabliereApi.Donnees.Action.Post;
+
+/// <summary>
+/// Modèle de création d'une ligne de tubelure. Ne contient volontairement aucune
+/// propriété de navigation afin d'empêcher l'over-posting vers des entités liées.
+/// </summary>
+public class PostLigneTubelure
+{
+    /// <summary>
+    /// L'id guid si le client désire initialiser l'id
+    /// </summary>
+    public Guid? Id { get; set; }
+
+    /// <summary>
+    /// La clé étrangère de l'érablière
+    /// </summary>
+    public Guid? IdErabliere { get; set; }
+
+    /// <summary>
+    /// Le nom de la ligne (ex: M-01)
+    /// </summary>
+    [MaxLength(100, ErrorMessage = "Le nom de la ligne ne peut pas dépasser 100 caractères.")]
+    public string? Nom { get; set; }
+
+    /// <summary>
+    /// Le type de la ligne. Voir <see cref="Contantes.TypeLigneTubelure" /> pour les valeurs permises.
+    /// </summary>
+    [MaxLength(20, ErrorMessage = "Le type de la ligne ne peut pas dépasser 20 caractères.")]
+    public string? TypeLigne { get; set; }
+
+    /// <summary>
+    /// Les coordonnées de la ligne sous forme de tableau JSON de paires [longitude, latitude],
+    /// dans l'ordre du tracé. Ex: [[-71.25, 46.82], [-71.26, 46.83]]
+    /// </summary>
+    public string? CoordonneesJson { get; set; }
+}

--- a/ErabliereModel/Action/Put/PutAlerte.cs
+++ b/ErabliereModel/Action/Put/PutAlerte.cs
@@ -1,0 +1,80 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ErabliereApi.Donnees.Action.Put;
+
+/// <summary>
+/// Modèle de modification d'une alerte (trio de données). Ne contient volontairement aucune
+/// propriété de navigation afin d'empêcher l'over-posting vers des entités liées.
+/// </summary>
+public class PutAlerte
+{
+    /// <summary>
+    /// L'id de l'alerte à modifier
+    /// </summary>
+    public Guid? Id { get; set; }
+
+    /// <summary>
+    /// La clé étrangère de l'érablière
+    /// </summary>
+    public Guid? IdErabliere { get; set; }
+
+    /// <summary>
+    /// Le nom de l'alerte
+    /// </summary>
+    [MaxLength(100)]
+    public string? Nom { get; set; }
+
+    /// <summary>
+    /// Une liste d'adresse email séparer par des ';'
+    /// </summary>
+    [MaxLength(200)]
+    public string? EnvoyerA { get; set; }
+
+    /// <summary>
+    /// Une liste de numéros de téléphone séparés par des ';'
+    /// </summary>
+    [MaxLength(200)]
+    public string? TexterA { get; set; }
+
+    /// <summary>
+    /// Seuil de température bas
+    /// </summary>
+    [MaxLength(50)]
+    public string? TemperatureThresholdLow { get; set; }
+
+    /// <summary>
+    /// Seuil de température haut
+    /// </summary>
+    [MaxLength(50)]
+    public string? TemperatureThresholdHight { get; set; }
+
+    /// <summary>
+    /// Seuil de vacuum bas
+    /// </summary>
+    [MaxLength(50)]
+    public string? VacciumThresholdLow { get; set; }
+
+    /// <summary>
+    /// Seuil de vacuum haut
+    /// </summary>
+    [MaxLength(50)]
+    public string? VacciumThresholdHight { get; set; }
+
+    /// <summary>
+    /// Seuil de niveau de bassin bas
+    /// </summary>
+    [MaxLength(50)]
+    public string? NiveauBassinThresholdLow { get; set; }
+
+    /// <summary>
+    /// Seuil de niveau de bassin haut
+    /// </summary>
+    [MaxLength(50)]
+    public string? NiveauBassinThresholdHight { get; set; }
+
+    /// <summary>
+    /// Indique si l'alerte est activé
+    /// </summary>
+    public bool IsEnable { get; set; }
+}

--- a/ErabliereModel/Action/Put/PutArbre.cs
+++ b/ErabliereModel/Action/Put/PutArbre.cs
@@ -1,0 +1,43 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ErabliereApi.Donnees.Action.Put;
+
+/// <summary>
+/// Modèle de modification d'un arbre cartographié. Ne contient volontairement aucune
+/// propriété de navigation afin d'empêcher l'over-posting vers des entités liées.
+/// </summary>
+public class PutArbre
+{
+    /// <summary>
+    /// L'id de l'arbre à modifier
+    /// </summary>
+    public Guid? Id { get; set; }
+
+    /// <summary>
+    /// La clé étrangère de l'érablière
+    /// </summary>
+    public Guid? IdErabliere { get; set; }
+
+    /// <summary>
+    /// L'identifiant ou le nom de l'arbre
+    /// </summary>
+    [MaxLength(100, ErrorMessage = "Le nom de l'arbre ne peut pas dépasser 100 caractères.")]
+    public string? Nom { get; set; }
+
+    /// <summary>
+    /// L'espèce de l'arbre
+    /// </summary>
+    [MaxLength(50, ErrorMessage = "L'espèce de l'arbre ne peut pas dépasser 50 caractères.")]
+    public string? Espece { get; set; }
+
+    /// <summary>
+    /// La latitude de l'arbre
+    /// </summary>
+    public double Latitude { get; set; }
+
+    /// <summary>
+    /// La longitude de l'arbre
+    /// </summary>
+    public double Longitude { get; set; }
+}

--- a/ErabliereModel/Action/Put/PutBaril.cs
+++ b/ErabliereModel/Action/Put/PutBaril.cs
@@ -1,0 +1,38 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ErabliereApi.Donnees.Action.Put;
+
+/// <summary>
+/// Modèle de modification d'un baril. Ne contient volontairement aucune propriété de navigation
+/// afin d'empêcher l'over-posting vers des entités liées.
+/// </summary>
+public class PutBaril
+{
+    /// <summary>
+    /// L'id du baril à modifier
+    /// </summary>
+    public Guid? Id { get; set; }
+
+    /// <summary>
+    /// La clé étrangère de l'érablière possédant le baril
+    /// </summary>
+    public Guid? IdErabliere { get; set; }
+
+    /// <summary>
+    /// Date où le baril a été fermé
+    /// </summary>
+    public DateTimeOffset? DF { get; set; }
+
+    /// <summary>
+    /// Estimation de la qualité du sirop
+    /// </summary>
+    [MaxLength(15)]
+    public string? QE { get; set; }
+
+    /// <summary>
+    /// Qualité du sirop après classement
+    /// </summary>
+    [MaxLength(15)]
+    public string? Q { get; set; }
+}

--- a/ErabliereModel/Action/Put/PutDompeux.cs
+++ b/ErabliereModel/Action/Put/PutDompeux.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace ErabliereApi.Donnees.Action.Put;
+
+/// <summary>
+/// Modèle de modification d'un dompeux. Ne contient volontairement aucune propriété de navigation
+/// afin d'empêcher l'over-posting vers des entités liées.
+/// </summary>
+public class PutDompeux
+{
+    /// <summary>
+    /// L'id du dompeux à modifier
+    /// </summary>
+    public Guid? Id { get; set; }
+
+    /// <summary>
+    /// La clé étrangère de l'érablière
+    /// </summary>
+    public Guid? IdErabliere { get; set; }
+
+    /// <summary>
+    /// Date de l'occurence
+    /// </summary>
+    public DateTimeOffset? T { get; set; }
+
+    /// <summary>
+    /// La date de début
+    /// </summary>
+    public DateTimeOffset? DD { get; set; }
+
+    /// <summary>
+    /// La date de fin
+    /// </summary>
+    public DateTimeOffset? DF { get; set; }
+}

--- a/ErabliereModel/Action/Put/PutDonneeCapteur.cs
+++ b/ErabliereModel/Action/Put/PutDonneeCapteur.cs
@@ -1,0 +1,38 @@
+using ErabliereApi.Donnees.Contantes;
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ErabliereApi.Donnees.Action.Put;
+
+/// <summary>
+/// Modèle de modification d'une donnée de capteur. Ne contient volontairement aucune propriété
+/// de navigation afin d'empêcher l'over-posting vers des entités liées.
+/// </summary>
+public class PutDonneeCapteur
+{
+    /// <summary>
+    /// L'id de la donnée du capteur à modifier
+    /// </summary>
+    public Guid? Id { get; set; }
+
+    /// <summary>
+    /// L'id du capteur de la donnée
+    /// </summary>
+    public Guid? IdCapteur { get; set; }
+
+    /// <summary>
+    /// La valeur de la donnée
+    /// </summary>
+    public decimal? Valeur { get; set; }
+
+    /// <summary>
+    /// Text associé à la donnée
+    /// </summary>
+    [MaxLength(Specifications.DonnesCapteurTextMaxLength)]
+    public string? Text { get; set; }
+
+    /// <summary>
+    /// La date de création
+    /// </summary>
+    public DateTimeOffset? D { get; set; }
+}

--- a/ErabliereModel/Action/Put/PutEntaille.cs
+++ b/ErabliereModel/Action/Put/PutEntaille.cs
@@ -1,0 +1,47 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ErabliereApi.Donnees.Action.Put;
+
+/// <summary>
+/// Modèle de modification d'une entaille cartographiée. Ne contient volontairement aucune
+/// propriété de navigation afin d'empêcher l'over-posting vers des entités liées.
+/// </summary>
+public class PutEntaille
+{
+    /// <summary>
+    /// L'id de l'entaille à modifier
+    /// </summary>
+    public Guid? Id { get; set; }
+
+    /// <summary>
+    /// La clé étrangère de l'érablière
+    /// </summary>
+    public Guid? IdErabliere { get; set; }
+
+    /// <summary>
+    /// L'identifiant ou le nom de l'entaille
+    /// </summary>
+    [MaxLength(100, ErrorMessage = "Le nom de l'entaille ne peut pas dépasser 100 caractères.")]
+    public string? Nom { get; set; }
+
+    /// <summary>
+    /// La latitude de l'entaille
+    /// </summary>
+    public double Latitude { get; set; }
+
+    /// <summary>
+    /// La longitude de l'entaille
+    /// </summary>
+    public double Longitude { get; set; }
+
+    /// <summary>
+    /// La clé étrangère optionnelle de l'arbre entaillé
+    /// </summary>
+    public Guid? IdArbre { get; set; }
+
+    /// <summary>
+    /// La clé étrangère optionnelle de la ligne de tubelure raccordée
+    /// </summary>
+    public Guid? IdLigneTubelure { get; set; }
+}

--- a/ErabliereModel/Action/Put/PutLigneTubelure.cs
+++ b/ErabliereModel/Action/Put/PutLigneTubelure.cs
@@ -1,0 +1,39 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ErabliereApi.Donnees.Action.Put;
+
+/// <summary>
+/// Modèle de modification d'une ligne de tubelure. Ne contient volontairement aucune
+/// propriété de navigation afin d'empêcher l'over-posting vers des entités liées.
+/// </summary>
+public class PutLigneTubelure
+{
+    /// <summary>
+    /// L'id de la ligne à modifier
+    /// </summary>
+    public Guid? Id { get; set; }
+
+    /// <summary>
+    /// La clé étrangère de l'érablière
+    /// </summary>
+    public Guid? IdErabliere { get; set; }
+
+    /// <summary>
+    /// Le nom de la ligne (ex: M-01)
+    /// </summary>
+    [MaxLength(100, ErrorMessage = "Le nom de la ligne ne peut pas dépasser 100 caractères.")]
+    public string? Nom { get; set; }
+
+    /// <summary>
+    /// Le type de la ligne. Voir <see cref="Contantes.TypeLigneTubelure" /> pour les valeurs permises.
+    /// </summary>
+    [MaxLength(20, ErrorMessage = "Le type de la ligne ne peut pas dépasser 20 caractères.")]
+    public string? TypeLigne { get; set; }
+
+    /// <summary>
+    /// Les coordonnées de la ligne sous forme de tableau JSON de paires [longitude, latitude],
+    /// dans l'ordre du tracé. Ex: [[-71.25, 46.82], [-71.26, 46.83]]
+    /// </summary>
+    public string? CoordonneesJson { get; set; }
+}

--- a/ErabliereModel/Arbre.cs
+++ b/ErabliereModel/Arbre.cs
@@ -1,0 +1,63 @@
+using ErabliereApi.Donnees.Interfaces;
+using ErabliereApi.Donnees.Ownable;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace ErabliereApi.Donnees;
+
+/// <summary>
+/// Un arbre cartographié dans une érablière
+/// </summary>
+public class Arbre : IIdentifiable<Guid?, Arbre>, IErabliereOwnable, ILocalizable, IDatesInfo
+{
+    /// <summary>
+    /// La clé primaire
+    /// </summary>
+    public Guid? Id { get; set; }
+
+    /// <summary>
+    /// La clé étrangère de l'érablière
+    /// </summary>
+    public Guid? IdErabliere { get; set; }
+
+    /// <summary>
+    /// L'érablière qui possède l'arbre
+    /// </summary>
+    public Erabliere? Erabliere { get; set; }
+
+    /// <summary>
+    /// L'identifiant ou le nom de l'arbre
+    /// </summary>
+    [MaxLength(100, ErrorMessage = "Le nom de l'arbre ne peut pas dépasser 100 caractères.")]
+    public string? Nom { get; set; }
+
+    /// <summary>
+    /// L'espèce de l'arbre
+    /// </summary>
+    [MaxLength(50, ErrorMessage = "L'espèce de l'arbre ne peut pas dépasser 50 caractères.")]
+    public string? Espece { get; set; }
+
+    /// <inheritdoc />
+    public double Latitude { get; set; }
+
+    /// <inheritdoc />
+    public double Longitude { get; set; }
+
+    /// <summary>
+    /// Les entailles de l'arbre
+    /// </summary>
+    public List<Entaille>? Entailles { get; set; }
+
+    /// <inheritdoc />
+    public DateTimeOffset? DC { get; set; }
+
+    /// <inheritdoc />
+    public DateTimeOffset? DM { get; set; }
+
+    /// <inheritdoc />
+    public int CompareTo(Arbre? other)
+    {
+        return 0;
+    }
+}

--- a/ErabliereModel/Contantes/TypeLigneTubelure.cs
+++ b/ErabliereModel/Contantes/TypeLigneTubelure.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Linq;
+
+namespace ErabliereApi.Donnees.Contantes;
+
+/// <summary>
+/// Les types de ligne de tubelure supportés
+/// </summary>
+public static class TypeLigneTubelure
+{
+    /// <summary>
+    /// Ligne principale (maîtresse / main)
+    /// </summary>
+    public const string Principale = "principale";
+
+    /// <summary>
+    /// Ligne secondaire (collectrice)
+    /// </summary>
+    public const string Secondaire = "secondaire";
+
+    /// <summary>
+    /// Ligne latérale (5/16)
+    /// </summary>
+    public const string Laterale = "laterale";
+
+    /// <summary>
+    /// La liste de tous les types de ligne valides
+    /// </summary>
+    public static readonly string[] Tous = [Principale, Secondaire, Laterale];
+
+    /// <summary>
+    /// Valide qu'un type de ligne fait partie de la liste des types supportés
+    /// </summary>
+    public static bool EstValide(string? type)
+    {
+        return type != null && Tous.Contains(type.ToLowerInvariant());
+    }
+}

--- a/ErabliereModel/Entaille.cs
+++ b/ErabliereModel/Entaille.cs
@@ -1,0 +1,72 @@
+using ErabliereApi.Donnees.Interfaces;
+using ErabliereApi.Donnees.Ownable;
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ErabliereApi.Donnees;
+
+/// <summary>
+/// Une entaille cartographiée dans une érablière. Peut optionnellement être rattachée
+/// à un arbre et/ou à une ligne de tubelure.
+/// </summary>
+public class Entaille : IIdentifiable<Guid?, Entaille>, IErabliereOwnable, ILocalizable, IDatesInfo
+{
+    /// <summary>
+    /// La clé primaire
+    /// </summary>
+    public Guid? Id { get; set; }
+
+    /// <summary>
+    /// La clé étrangère de l'érablière
+    /// </summary>
+    public Guid? IdErabliere { get; set; }
+
+    /// <summary>
+    /// L'érablière qui possède l'entaille
+    /// </summary>
+    public Erabliere? Erabliere { get; set; }
+
+    /// <summary>
+    /// L'identifiant ou le nom de l'entaille
+    /// </summary>
+    [MaxLength(100, ErrorMessage = "Le nom de l'entaille ne peut pas dépasser 100 caractères.")]
+    public string? Nom { get; set; }
+
+    /// <inheritdoc />
+    public double Latitude { get; set; }
+
+    /// <inheritdoc />
+    public double Longitude { get; set; }
+
+    /// <summary>
+    /// La clé étrangère optionnelle de l'arbre entaillé
+    /// </summary>
+    public Guid? IdArbre { get; set; }
+
+    /// <summary>
+    /// L'arbre entaillé
+    /// </summary>
+    public Arbre? Arbre { get; set; }
+
+    /// <summary>
+    /// La clé étrangère optionnelle de la ligne de tubelure raccordée
+    /// </summary>
+    public Guid? IdLigneTubelure { get; set; }
+
+    /// <summary>
+    /// La ligne de tubelure raccordée
+    /// </summary>
+    public LigneTubelure? LigneTubelure { get; set; }
+
+    /// <inheritdoc />
+    public DateTimeOffset? DC { get; set; }
+
+    /// <inheritdoc />
+    public DateTimeOffset? DM { get; set; }
+
+    /// <inheritdoc />
+    public int CompareTo(Entaille? other)
+    {
+        return 0;
+    }
+}

--- a/ErabliereModel/Erabliere.cs
+++ b/ErabliereModel/Erabliere.cs
@@ -156,6 +156,21 @@ public class Erabliere : IIdentifiable<Guid?, Erabliere>, IUserOwnable, ILocaliz
     public List<Horaire>? Horaires { get; set; }
 
     /// <summary>
+    /// Les lignes du réseau de tubelure de l'érablière
+    /// </summary>
+    public List<LigneTubelure>? LignesTubelure { get; set; }
+
+    /// <summary>
+    /// Les arbres cartographiés de l'érablière
+    /// </summary>
+    public List<Arbre>? Arbres { get; set; }
+
+    /// <summary>
+    /// Les entailles cartographiées de l'érablière
+    /// </summary>
+    public List<Entaille>? Entailles { get; set; }
+
+    /// <summary>
     /// Liste de jonction entre l'utilisateurs et ses érablières
     /// </summary>
     public List<CustomerErabliere>? CustomerErablieres { get; set; }

--- a/ErabliereModel/LigneTubelure.cs
+++ b/ErabliereModel/LigneTubelure.cs
@@ -1,0 +1,63 @@
+using ErabliereApi.Donnees.Interfaces;
+using ErabliereApi.Donnees.Ownable;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace ErabliereApi.Donnees;
+
+/// <summary>
+/// Une ligne du réseau de tubelure d'une érablière
+/// </summary>
+public class LigneTubelure : IIdentifiable<Guid?, LigneTubelure>, IErabliereOwnable, IDatesInfo
+{
+    /// <summary>
+    /// La clé primaire
+    /// </summary>
+    public Guid? Id { get; set; }
+
+    /// <summary>
+    /// La clé étrangère de l'érablière
+    /// </summary>
+    public Guid? IdErabliere { get; set; }
+
+    /// <summary>
+    /// L'érablière qui possède la ligne
+    /// </summary>
+    public Erabliere? Erabliere { get; set; }
+
+    /// <summary>
+    /// Le nom de la ligne (ex: M-01)
+    /// </summary>
+    [MaxLength(100, ErrorMessage = "Le nom de la ligne ne peut pas dépasser 100 caractères.")]
+    public string? Nom { get; set; }
+
+    /// <summary>
+    /// Le type de la ligne. Voir <see cref="Contantes.TypeLigneTubelure" /> pour les valeurs permises.
+    /// </summary>
+    [MaxLength(20, ErrorMessage = "Le type de la ligne ne peut pas dépasser 20 caractères.")]
+    public string? TypeLigne { get; set; }
+
+    /// <summary>
+    /// Les coordonnées de la ligne sous forme de tableau JSON de paires [longitude, latitude],
+    /// dans l'ordre du tracé. Ex: [[-71.25, 46.82], [-71.26, 46.83]]
+    /// </summary>
+    public string? CoordonneesJson { get; set; }
+
+    /// <summary>
+    /// Les entailles raccordées à cette ligne
+    /// </summary>
+    public List<Entaille>? Entailles { get; set; }
+
+    /// <inheritdoc />
+    public DateTimeOffset? DC { get; set; }
+
+    /// <inheritdoc />
+    public DateTimeOffset? DM { get; set; }
+
+    /// <inheritdoc />
+    public int CompareTo(LigneTubelure? other)
+    {
+        return 0;
+    }
+}


### PR DESCRIPTION
## Résumé

Permet à un utilisateur de cartographier le réseau de tubelure de son érablière en marchant avec son téléphone, puis d'afficher le réseau sur la carte mapbox. (Projet « tubing-mapper » de la roadmap 2026.)

### Backend
- Nouvelles entités `LigneTubelure` (3 types : principale, secondaire, latérale ; géométrie stockée en colonne JSON `[[lng,lat],...]`), `Arbre` et `Entaille` (position propre + liens optionnels vers un arbre et/ou une ligne).
- Contrôleurs CRUD OData sous `Erablieres/{id}/LignesTubelure|Arbres|Entailles` + endpoint `Erablieres/{id}/Tubelure/GeoJson` retournant la FeatureCollection complète.
- Validations : type de ligne, ≥ 2 points (max 10 000), bornes lat/lng, les liens d'une entaille doivent appartenir à la même érablière.
- Migration `AjoutTubelure`. Les FKs `Arbre→Entaille` et `Ligne→Entaille` sont en `ClientSetNull` (évite les chemins de cascade multiples refusés par SQL Server) ; supprimer un arbre ou une ligne délie les entailles au lieu de les supprimer.

### Frontend
- Nouvelle page « Tubelure » (`e/:id/tubelure`, entrée au menu gardée par la disponibilité du token Mapbox).
- Saisie terrain : choix du type de ligne, point à la position GPS (`GeolocateControl` haute précision, badge « GPS ± Xm ») ou tap sur la carte, retrait du dernier point, glisser un sommet pour le corriger.
- Arbres et entailles par tap ou position GPS via modale (sélection optionnelle d'arbre/ligne pour l'entaille).
- Affichage : lignes colorées par type, cercles arbres/entailles, légende, popups Modifier/Supprimer.

### Tests
- 5 nouveaux tests d'intégration (`TubelureTest.cs`) : validations, GeoJson, suppression d'arbre qui délie l'entaille.
- Les 3 nouvelles navigations sur `Erabliere` cassaient les tests AutoFixture (référence circulaire) → `.Without(...)` ajoutés dans `ErabliereFixture.cs`.
- `dotnet build` + `dotnet test` : 70/70 ✅ ; `npm run build` ✅.

### Hors scope v1
Capture hors-ligne (file d'attente IndexedDB + PWA) — à considérer pour une v2 vu la connectivité en forêt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnCfzYc1irHB8dzHFF9xUP
